### PR TITLE
feat(privacy, terms): add Privacy Policy and Terms of Service pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -166,7 +166,7 @@ export default function RootLayout({
                   <Link href="/terms" className="hover:text-sky-600 transition-colors">
                     Terms of Service
                   </Link>
-                  <Link href="/contact" className="hover:text-sky-600 transition-colors">
+                  <Link href="https://bento.me/darshan3690" target="_blank" rel="noopener noreferrer" className="hover:text-sky-600 transition-colors">
                     Contact
                   </Link>
                 </div>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,175 @@
+import React from "react";
+import Link from "next/link";
+
+export default function PrivacyPage() {
+  return (
+    <main className="max-w-3xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
+      <article className="prose prose-lg">
+        <header>
+          <h1 className="text-3xl sm:text-4xl font-extrabold text-blue-600">
+            Privacy Policy
+          </h1>
+        </header>
+
+        <section className="mt-6">
+          <p style={{ color: '#0F0E0E' }} className="leading-relaxed">
+            How The-Dev-Pocket collects, uses, and protects your personal information when you use our educational platform and services.
+          </p>
+        </section>
+
+        <section className="mt-8">
+          <h2 className="text-xl font-semibold text-blue-600">1. Information We Collect</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Account Information:</strong> We collect information you provide when registering, including name, email address, username, and profile details.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Usage Data:</strong> We automatically collect information about how you use our platform, including pages visited, features used, learning progress, time spent, and interaction patterns.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Community Contributions:</strong> Content you submit to open-source repositories, community discussions, forums, and educational materials.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Technical Information:</strong> Device information, IP address, browser type, operating system, and cookies for platform functionality and analytics.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Payment Information:</strong> Billing details for premium services, processed securely through third-party payment processors. We do not store complete payment card information.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">2. How We Use Your Information</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">We use collected information to:</p>
+          <ul className="list-disc pl-6 mt-3" style={{ color: '#0F0E0E' }}>
+            <li>Provide and improve our educational services and tools</li>
+            <li>Personalize learning experiences and content recommendations</li>
+            <li>Process payments and manage premium subscriptions</li>
+            <li>Facilitate community interactions and open-source contributions</li>
+            <li>Send important updates, security alerts, and educational content</li>
+            <li>Analyze platform usage to enhance features and performance</li>
+            <li>Ensure platform security and prevent fraudulent activities</li>
+          </ul>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">3. Information Sharing and Disclosure</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Community Content:</strong> Your contributions to open-source projects, forums, and community sections are publicly visible and may be shared under applicable open-source licenses.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Service Providers:</strong> We share information with trusted third-party service providers who assist in platform operations, payment processing, analytics, and customer support.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Legal Requirements:</strong> We may disclose information when required by law, court orders, or to protect our rights and user safety.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Business Transfers:</strong> In the event of merger, acquisition, or sale, user information may be transferred as part of business assets.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            We do not sell personal information to third parties for marketing purposes.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">4. Data Security and Protection</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">We implement industry-standard security measures to protect your information, including:</p>
+          <ul className="list-disc pl-6 mt-3" style={{ color: '#0F0E0E' }}>
+            <li>Encryption of data in transit and at rest</li>
+            <li>Secure authentication and access controls</li>
+            <li>Regular security assessments and updates</li>
+            <li>Limited access to personal information on a need-to-know basis</li>
+          </ul>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            However, no internet transmission is completely secure, and we cannot guarantee absolute security.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">5. Your Privacy Rights and Choices</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Account Management:</strong> You can update, correct, or delete your account information through your profile settings.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Communication Preferences:</strong> You may opt-out of promotional emails while continuing to receive essential service communications.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Data Access:</strong> You can request access to personal information we hold about you.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Data Deletion:</strong> You may request deletion of your account and associated personal information, subject to legal and operational requirements.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Cookie Control:</strong> Most browsers allow you to control cookie settings, though this may affect platform functionality.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">6. Children's Privacy</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            Our platform is not intended for users under 13 years of age. We do not knowingly collect personal information from children under 13. If we become aware of such collection, we will delete the information promptly.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">7. International Data Transfers</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            Your information may be processed and stored in countries other than your residence. We ensure appropriate safeguards are in place for international data transfers in compliance with applicable privacy laws.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">8. Third-Party Services and Links</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            Our platform may contain links to external websites or integrate with third-party services. This Privacy Policy does not apply to third-party sites, and we encourage you to review their privacy practices.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">9. Data Retention</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            We retain personal information for as long as necessary to provide services, comply with legal obligations, and resolve disputes. Account information is typically retained until account deletion, while community contributions may remain publicly available under open-source licenses.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">10. Analytics and Tracking</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            We use analytics tools to understand platform usage and improve user experience. These tools may collect information about your interactions, which is used in aggregate form for analysis purposes.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">11. Updates to Privacy Policy</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            We may update this Privacy Policy periodically to reflect changes in our practices or legal requirements. Material changes will be communicated through email or platform notifications. Continued use after updates constitutes acceptance of the revised policy.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">12. Regional Privacy Rights</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>European Users:</strong> Under GDPR, you have rights to access, rectify, erase, restrict processing, data portability, and object to processing of your personal information.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>California Users:</strong> Under CCPA, you have rights to know what personal information is collected, request deletion, and opt-out of sale of personal information.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">13. Contact Information</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            For privacy-related questions, requests, or concerns:
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <a href="https://bento.me/darshan3690" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">
+              https://bento.me/darshan3690
+            </a>
+          </p>
+        </section>
+
+        <footer className="mt-10">
+          <p style={{ color: '#0F0E0E' }} className="text-sm">By using The-Dev-Pocket, you acknowledge that you have read and understood this Privacy Policy and consent to our privacy practices as described herein.</p>
+        </footer>
+      </article>
+    </main>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import Link from "next/link";
+
+export default function TermsPage() {
+  return (
+    <main className="max-w-3xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
+      <article className="prose prose-lg">
+        <header>
+          <h1 className="text-3xl sm:text-4xl font-extrabold text-blue-600">
+            Terms of Service Agreement
+          </h1>
+        </header>
+
+        <section className="mt-6">
+          <p style={{ color: '#0F0E0E' }} className="leading-relaxed">
+            These Terms of Service constitute a binding agreement between you ("User") and The-Dev-Pocket governing your use of our educational platform and services.
+          </p>
+        </section>
+
+        <section className="mt-8">
+          <h2 className="text-xl font-semibold text-blue-600">1. Acceptance and Platform Overview</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            By accessing The-Dev-Pocket, you agree to these Terms. Our platform provides curated learning resources for Web Development, Data Structures & Algorithms, AI/ML, interactive coding tools, structured roadmaps, and community-driven open-source content.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">2. User Registration and Responsibilities</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            You must provide accurate registration information and maintain account security. You are solely responsible for all activities under your account and must notify us immediately of any unauthorized access or security breaches.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">3. Acceptable Use Policy</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">Users are prohibited from:</p>
+          <ul className="list-disc pl-6 mt-3" style={{ color: '#0F0E0E' }}>
+            <li>Uploading illegal, harmful, or offensive content</li>
+            <li>Violating intellectual property rights of third parties</li>
+            <li>Attempting unauthorized access to systems or user accounts</li>
+            <li>Engaging in spam, harassment, or deceptive practices</li>
+            <li>Submitting low-quality or malicious contributions to open-source projects</li>
+          </ul>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">4. Intellectual Property and Content Rights</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Platform Content:</strong> All educational materials, interactive tools, roadmaps, and proprietary content are protected by intellectual property laws. Users receive a limited, non-transferable license for personal educational use only.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Community Contributions:</strong> By submitting content to our open-source repositories, community sections, or Hacktoberfest initiatives, you grant Company a perpetual, worldwide, royalty-free license to use, modify, and distribute your contributions. You retain ownership of your original work while allowing community usage under applicable open-source licenses.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">5. Payment Terms and Premium Services</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            Certain advanced features, specialized tools, or premium educational content require payment. All transactions are processed through secure third-party payment processors compliant with industry standards.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <strong>Billing and Refunds:</strong> Payments are due immediately upon purchase confirmation. Refund requests must be submitted within thirty (30) days and are subject to our discretion and refund policy guidelines.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">6. Community Standards and Open Source Participation</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            As a community-driven platform, all users must maintain professional conduct and provide constructive contributions. Participation in Hacktoberfest and similar open-source programs must adhere to quality standards and program-specific rules. We reserve the right to reject contributions that fail to meet educational or technical standards.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">7. Privacy and Data Protection</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            Collection and processing of personal information, educational progress, and community interactions are governed by our Privacy Policy, which is incorporated herein by reference.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">8. Service Availability and Modifications</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            While we strive to maintain optimal platform performance, we do not guarantee uninterrupted service. Company reserves the right to modify, suspend, or discontinue features with reasonable notice and shall not be liable for such changes.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">9. Disclaimers and Limitation of Liability</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            THE PLATFORM IS PROVIDED "AS IS" WITHOUT WARRANTIES OF ANY KIND. COMPANY MAKES NO GUARANTEES REGARDING EDUCATIONAL OUTCOMES, SKILL ACQUISITION, OR CAREER ADVANCEMENT.
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            TO THE MAXIMUM EXTENT PERMITTED BY LAW, COMPANY'S LIABILITY SHALL NOT EXCEED THE AMOUNT PAID BY USER IN THE PRECEDING TWELVE (12) MONTHS. WE ARE NOT LIABLE FOR INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">10. Account Termination</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            Company may suspend or terminate accounts for violations of these Terms, community guidelines, or misuse of educational resources. Upon termination, access to premium features ceases, though community contributions may remain accessible under open-source licenses.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">11. Dispute Resolution and Governing Law</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            Disputes arising under these Terms shall be resolved through binding arbitration. This Agreement is governed by the laws of [State/Country], without regard to conflict of law principles.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">12. Modifications to Terms</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            Company reserves the right to modify these Terms at any time. Material changes will be communicated through the platform or email. Continued use after modifications constitutes acceptance of revised Terms.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">13. Entire Agreement</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            These Terms, together with our Privacy Policy, constitute the entire agreement between User and Company, superseding all prior agreements and understandings.
+          </p>
+        </section>
+
+        <section className="mt-6">
+          <h2 className="text-xl font-semibold text-blue-600">14. Contact Information</h2>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            For questions regarding these Terms or legal matters:
+          </p>
+          <p style={{ color: '#0F0E0E' }} className="mt-3 leading-relaxed">
+            <a href="https://bento.me/darshan3690" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">
+              https://bento.me/darshan3690
+            </a>
+          </p>
+        </section>
+
+        <footer className="mt-10">
+          <p style={{ color: '#0F0E0E' }} className="text-sm">By using The-Dev-Pocket, you acknowledge that you have read, understood, and agree to be bound by these Terms of Service.</p>
+        </footer>
+      </article>
+    </main>
+  );
+}


### PR DESCRIPTION
(issue #71) 
This pull request introduces the full Privacy Policy and Terms of Service pages for the platform, providing users with clear legal and privacy information. Additionally, the "Contact" link in the site layout is updated to direct users to an external contact page.

**Legal and Policy Documentation:**

* Added a comprehensive Privacy Policy page at `app/privacy/page.tsx`, outlining data collection, usage, sharing, user rights, security measures, and regional privacy laws.
* Added a detailed Terms of Service page at `app/terms/page.tsx`, covering user responsibilities, acceptable use, intellectual property, payment terms, community standards, liability, and dispute resolution.

**Navigation and Contact Updates:**

* Updated the "Contact" link in the site footer within `app/layout.tsx` to point to an external contact page (`https://bento.me/darshan3690`) and open in a new tab for improved accessibility.# 📥 Pull Request Template

## 📝 Description

Briefly describe the changes you made.

added universal TOS and privacy policy,contact in footer leads to your portfolio


---------------------------------------

## 📸 Screenshots (if applicable)


<img width="1919" height="875" alt="Screenshot 2025-10-01 145406" src="https://github.com/user-attachments/assets/771059fd-3cea-403c-9cac-22850bde7515" />

<img width="1915" height="849" alt="Screenshot 2025-10-01 145352" src="https://github.com/user-attachments/assets/606004df-1e14-4b43-b58c-786583c678fe" />


____


