### PR TITLE
Remove dotted line from Get Started section for cleaner design

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -266,11 +266,6 @@ const App = () => {
           Get Started in 3 Simple Steps
         </h2>
         <div className="mt-8 grid grid-cols-1 md:grid-cols-3 gap-8 relative">
-          {/* Dotted line for desktop */}
-          <div
-            className="hidden md:block absolute top-1/2 left-0 w-full h-0.5 border-t-2 border-dashed border-sky-300"
-            style={{ transform: "translateY(-50%)", zIndex: -1 }}
-          ></div>
           <div className="relative">
             <div className="w-12 h-12 bg-white border-2 border-sky-200 rounded-full flex items-center justify-center text-xl font-bold text-sky-600 mx-auto mb-3">
               1


### PR DESCRIPTION
## 📝 Description
Removed the dotted line from the "Get Started in 3 Simple Steps" section to improve the visual polish and modernize the homepage design. The numbered circles (1, 2, 3) provide sufficient visual progression without needing the connecting line.

**Changes made:**
- Removed dotted line element from the How It Works section (lines 201-206)
- No functional changes - layout and responsive behavior remain intact

**Fixes #52**

---

## ✅ Type of Change
* [ ] Bug fix 🐛
* [ ] New feature ✨
* [ ] Documentation update 📚
* [x] Other (please describe): Visual design improvement / UI enhancement

---

## 🔄 Checklist
* [x] My code follows the project's style guidelines
* [x] I have tested my changes locally
* [x] I have added necessary documentation (if applicable)
* [x] No sensitive data (keys, passwords) are included

---

## 📸 Screenshot
<img width="948" height="858" alt="image" src="https://github.com/user-attachments/assets/c39e28ab-d53e-439b-9829-1c6a268a4e75" />

*(Note: The "before" screenshot is already provided in issue #52)*
