### PR TITLE
fix: Add missing dashboard routes to resolve 404 errors

### DIFF
--- a/app/dashboard/forum/page.tsx
+++ b/app/dashboard/forum/page.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import { useState } from "react"
+import { Users, MessageSquare, ThumbsUp, Eye, Search, Plus, TrendingUp, Clock, Tag } from "lucide-react"
+
+const forumCategories = [
+  { id: "general", name: "General Discussion", posts: 234, color: "bg-blue-500" },
+  { id: "help", name: "Help & Support", posts: 156, color: "bg-green-500" },
+  { id: "showcase", name: "Project Showcase", posts: 89, color: "bg-purple-500" },
+  { id: "jobs", name: "Jobs & Opportunities", posts: 67, color: "bg-amber-500" },
+  { id: "resources", name: "Learning Resources", posts: 123, color: "bg-pink-500" },
+]
+
+const trendingPosts = [
+  {
+    title: "Best practices for React Server Components in 2024",
+    author: "Sarah Chen",
+    avatar: "SC",
+    category: "General Discussion",
+    replies: 45,
+    views: 1234,
+    likes: 89,
+    time: "2 hours ago",
+    tags: ["React", "Next.js", "RSC"]
+  },
+  {
+    title: "How I landed my first developer job - My journey",
+    author: "Mike Johnson",
+    avatar: "MJ",
+    category: "General Discussion",
+    replies: 78,
+    views: 2567,
+    likes: 156,
+    time: "5 hours ago",
+    tags: ["Career", "Interview", "Tips"]
+  },
+  {
+    title: "Need help with TypeScript generics",
+    author: "Alex Rivera",
+    avatar: "AR",
+    category: "Help & Support",
+    replies: 23,
+    views: 456,
+    likes: 34,
+    time: "1 day ago",
+    tags: ["TypeScript", "Help"]
+  },
+]
+
+export default function ForumPage() {
+  const [searchQuery, setSearchQuery] = useState("")
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
+
+  return (
+    <div className="space-y-8 max-w-6xl mx-auto">
+      {/* Header */}
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+          <div className="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-blue-100 to-indigo-100 rounded-full mb-4">
+            <Users className="w-5 h-5 text-blue-600" />
+            <span className="text-sm font-medium text-blue-700">Community Forum</span>
+          </div>
+          <h1 className="text-4xl font-bold bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
+            Community Forum
+          </h1>
+          <p className="text-slate-600 mt-2">Connect, share, and learn with fellow developers</p>
+        </div>
+        <button className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-blue-500 to-indigo-500 text-white font-semibold rounded-xl shadow-lg hover:shadow-xl transition-all hover:scale-105">
+          <Plus className="w-5 h-5" />
+          New Post
+        </button>
+      </div>
+
+      {/* Search Bar */}
+      <div className="relative">
+        <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400" />
+        <input
+          type="text"
+          placeholder="Search discussions..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="w-full pl-12 pr-4 py-4 bg-white border border-slate-200 rounded-2xl shadow-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none transition-all"
+        />
+      </div>
+
+      {/* Categories */}
+      <div className="flex flex-wrap gap-3">
+        {forumCategories.map((cat) => (
+          <button
+            key={cat.id}
+            onClick={() => setSelectedCategory(selectedCategory === cat.id ? null : cat.id)}
+            className={`inline-flex items-center gap-2 px-4 py-2 rounded-xl font-medium transition-all ${
+              selectedCategory === cat.id
+                ? "bg-blue-500 text-white shadow-lg"
+                : "bg-white text-slate-700 border border-slate-200 hover:border-blue-300"
+            }`}
+          >
+            <span className={`w-2 h-2 rounded-full ${cat.color}`} />
+            {cat.name}
+            <span className="text-xs opacity-70">({cat.posts})</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Trending Posts */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <TrendingUp className="w-5 h-5 text-orange-500" />
+          <h2 className="text-xl font-semibold text-slate-800">Trending Discussions</h2>
+        </div>
+        <div className="space-y-4">
+          {trendingPosts.map((post, idx) => (
+            <div
+              key={idx}
+              className="bg-white rounded-2xl p-6 shadow-lg border border-slate-200 hover:shadow-xl transition-all hover:border-blue-200 cursor-pointer group"
+            >
+              <div className="flex items-start gap-4">
+                <div className="w-12 h-12 rounded-full bg-gradient-to-br from-blue-500 to-indigo-500 flex items-center justify-center text-white font-bold flex-shrink-0">
+                  {post.avatar}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <h3 className="text-lg font-semibold text-slate-800 group-hover:text-blue-600 transition-colors mb-1">
+                    {post.title}
+                  </h3>
+                  <div className="flex flex-wrap items-center gap-3 text-sm text-slate-500 mb-3">
+                    <span>{post.author}</span>
+                    <span>•</span>
+                    <span className="flex items-center gap-1">
+                      <Clock className="w-4 h-4" /> {post.time}
+                    </span>
+                    <span>•</span>
+                    <span>{post.category}</span>
+                  </div>
+                  <div className="flex flex-wrap gap-2 mb-4">
+                    {post.tags.map((tag) => (
+                      <span key={tag} className="inline-flex items-center gap-1 px-2 py-1 bg-slate-100 text-slate-600 text-xs rounded-lg">
+                        <Tag className="w-3 h-3" /> {tag}
+                      </span>
+                    ))}
+                  </div>
+                  <div className="flex items-center gap-6 text-sm text-slate-500">
+                    <span className="flex items-center gap-1">
+                      <MessageSquare className="w-4 h-4" /> {post.replies} replies
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <Eye className="w-4 h-4" /> {post.views} views
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <ThumbsUp className="w-4 h-4" /> {post.likes} likes
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/projects/page.tsx
+++ b/app/dashboard/projects/page.tsx
@@ -1,0 +1,166 @@
+"use client"
+
+import { useState } from "react"
+import { Bot, Sparkles, Code, Lightbulb, ArrowRight, Loader2 } from "lucide-react"
+
+const projectCategories = [
+  { id: "web", name: "Web Development", icon: "🌐" },
+  { id: "mobile", name: "Mobile Apps", icon: "📱" },
+  { id: "ai", name: "AI/ML Projects", icon: "🤖" },
+  { id: "backend", name: "Backend/APIs", icon: "⚙️" },
+  { id: "fullstack", name: "Full Stack", icon: "🚀" },
+]
+
+const sampleProjects = [
+  {
+    title: "Personal Portfolio Website",
+    description: "Build a modern portfolio to showcase your work with animations and responsive design.",
+    difficulty: "Beginner",
+    tech: ["React", "Tailwind CSS", "Framer Motion"],
+    category: "web"
+  },
+  {
+    title: "Task Management API",
+    description: "Create a RESTful API with authentication, CRUD operations, and database integration.",
+    difficulty: "Intermediate",
+    tech: ["Node.js", "Express", "PostgreSQL", "JWT"],
+    category: "backend"
+  },
+  {
+    title: "AI Chat Assistant",
+    description: "Build a conversational AI assistant using modern LLM APIs and streaming responses.",
+    difficulty: "Advanced",
+    tech: ["Python", "FastAPI", "OpenAI", "WebSockets"],
+    category: "ai"
+  },
+]
+
+export default function ProjectsPage() {
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [skillLevel, setSkillLevel] = useState("intermediate")
+
+  const handleGenerate = () => {
+    setIsGenerating(true)
+    setTimeout(() => setIsGenerating(false), 2000)
+  }
+
+  return (
+    <div className="space-y-8 max-w-6xl mx-auto">
+      {/* Header */}
+      <div className="text-center space-y-4">
+        <div className="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-emerald-100 to-teal-100 rounded-full">
+          <Bot className="w-5 h-5 text-emerald-600" />
+          <span className="text-sm font-medium text-emerald-700">AI-Powered Recommendations</span>
+        </div>
+        <h1 className="text-4xl font-bold bg-gradient-to-r from-emerald-600 to-teal-600 bg-clip-text text-transparent">
+          AI Project Recommender
+        </h1>
+        <p className="text-slate-600 max-w-2xl mx-auto">
+          Get personalized project ideas based on your skills, interests, and career goals. 
+          Our AI analyzes your profile to suggest the perfect next project.
+        </p>
+      </div>
+
+      {/* Skill Level Selection */}
+      <div className="bg-white rounded-2xl p-6 shadow-lg border border-slate-200">
+        <h2 className="text-lg font-semibold text-slate-800 mb-4">Your Skill Level</h2>
+        <div className="flex flex-wrap gap-3">
+          {["beginner", "intermediate", "advanced"].map((level) => (
+            <button
+              key={level}
+              onClick={() => setSkillLevel(level)}
+              className={`px-6 py-3 rounded-xl font-medium capitalize transition-all ${
+                skillLevel === level
+                  ? "bg-gradient-to-r from-emerald-500 to-teal-500 text-white shadow-lg"
+                  : "bg-slate-100 text-slate-700 hover:bg-slate-200"
+              }`}
+            >
+              {level}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Category Selection */}
+      <div className="bg-white rounded-2xl p-6 shadow-lg border border-slate-200">
+        <h2 className="text-lg font-semibold text-slate-800 mb-4">Select a Category</h2>
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+          {projectCategories.map((cat) => (
+            <button
+              key={cat.id}
+              onClick={() => setSelectedCategory(cat.id)}
+              className={`p-4 rounded-xl text-center transition-all ${
+                selectedCategory === cat.id
+                  ? "bg-gradient-to-br from-emerald-500 to-teal-500 text-white shadow-lg scale-105"
+                  : "bg-slate-50 hover:bg-slate-100 text-slate-700"
+              }`}
+            >
+              <span className="text-2xl mb-2 block">{cat.icon}</span>
+              <span className="text-sm font-medium">{cat.name}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Generate Button */}
+      <div className="flex justify-center">
+        <button
+          onClick={handleGenerate}
+          disabled={isGenerating}
+          className="inline-flex items-center gap-3 px-8 py-4 bg-gradient-to-r from-emerald-500 to-teal-500 text-white font-semibold rounded-2xl shadow-lg hover:shadow-xl transition-all hover:scale-105 disabled:opacity-70 disabled:cursor-not-allowed"
+        >
+          {isGenerating ? (
+            <>
+              <Loader2 className="w-5 h-5 animate-spin" />
+              Generating Ideas...
+            </>
+          ) : (
+            <>
+              <Sparkles className="w-5 h-5" />
+              Generate Project Ideas
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* Sample Projects */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-slate-800">Recommended Projects</h2>
+        <div className="grid md:grid-cols-3 gap-6">
+          {sampleProjects.map((project, idx) => (
+            <div
+              key={idx}
+              className="bg-white rounded-2xl p-6 shadow-lg border border-slate-200 hover:shadow-xl transition-all hover:-translate-y-1 group"
+            >
+              <div className="flex items-start justify-between mb-4">
+                <span className={`px-3 py-1 rounded-full text-xs font-medium ${
+                  project.difficulty === "Beginner" ? "bg-green-100 text-green-700" :
+                  project.difficulty === "Intermediate" ? "bg-yellow-100 text-yellow-700" :
+                  "bg-red-100 text-red-700"
+                }`}>
+                  {project.difficulty}
+                </span>
+                <Lightbulb className="w-5 h-5 text-amber-500" />
+              </div>
+              <h3 className="text-lg font-semibold text-slate-800 mb-2 group-hover:text-emerald-600 transition-colors">
+                {project.title}
+              </h3>
+              <p className="text-slate-600 text-sm mb-4">{project.description}</p>
+              <div className="flex flex-wrap gap-2 mb-4">
+                {project.tech.map((t) => (
+                  <span key={t} className="px-2 py-1 bg-slate-100 text-slate-600 text-xs rounded-lg">
+                    {t}
+                  </span>
+                ))}
+              </div>
+              <button className="inline-flex items-center gap-2 text-emerald-600 font-medium text-sm group-hover:gap-3 transition-all">
+                Start Project <ArrowRight className="w-4 h-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/quick-start/page.tsx
+++ b/app/dashboard/quick-start/page.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import { useState } from "react"
+import { Zap, BookOpen, Code, Video, FileText, ArrowRight, Clock, Star, CheckCircle } from "lucide-react"
+
+const quickStartTopics = [
+  {
+    id: "javascript",
+    title: "JavaScript Fundamentals",
+    icon: "🟨",
+    duration: "2 hours",
+    lessons: 12,
+    rating: 4.9,
+    color: "from-yellow-400 to-amber-500"
+  },
+  {
+    id: "react",
+    title: "React Basics",
+    icon: "⚛️",
+    duration: "3 hours",
+    lessons: 15,
+    rating: 4.8,
+    color: "from-cyan-400 to-blue-500"
+  },
+  {
+    id: "typescript",
+    title: "TypeScript Essentials",
+    icon: "🔷",
+    duration: "2.5 hours",
+    lessons: 10,
+    rating: 4.7,
+    color: "from-blue-400 to-indigo-500"
+  },
+  {
+    id: "nodejs",
+    title: "Node.js Crash Course",
+    icon: "🟢",
+    duration: "2 hours",
+    lessons: 8,
+    rating: 4.8,
+    color: "from-green-400 to-emerald-500"
+  },
+  {
+    id: "python",
+    title: "Python for Beginners",
+    icon: "🐍",
+    duration: "3 hours",
+    lessons: 14,
+    rating: 4.9,
+    color: "from-emerald-400 to-teal-500"
+  },
+  {
+    id: "git",
+    title: "Git & GitHub",
+    icon: "📦",
+    duration: "1.5 hours",
+    lessons: 6,
+    rating: 4.6,
+    color: "from-orange-400 to-red-500"
+  },
+]
+
+export default function QuickStartPage() {
+  const [selectedTopic, setSelectedTopic] = useState<string | null>(null)
+
+  return (
+    <div className="space-y-8 max-w-6xl mx-auto">
+      {/* Header */}
+      <div className="text-center space-y-4">
+        <div className="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-pink-100 to-rose-100 rounded-full">
+          <Zap className="w-5 h-5 text-pink-600" />
+          <span className="text-sm font-medium text-pink-700">Jump Into Learning</span>
+        </div>
+        <h1 className="text-4xl font-bold bg-gradient-to-r from-pink-600 to-rose-600 bg-clip-text text-transparent">
+          Quick Start
+        </h1>
+        <p className="text-slate-600 max-w-2xl mx-auto">
+          Get started with any topic in minutes. Our curated quick-start guides help you learn the essentials fast.
+        </p>
+      </div>
+
+      {/* Quick Start Topics */}
+      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {quickStartTopics.map((topic) => (
+          <button
+            key={topic.id}
+            onClick={() => setSelectedTopic(topic.id)}
+            className={`relative overflow-hidden bg-white rounded-2xl p-6 shadow-lg border-2 transition-all hover:shadow-xl hover:-translate-y-1 text-left group ${
+              selectedTopic === topic.id ? "border-pink-500" : "border-slate-200"
+            }`}
+          >
+            <div className={`absolute top-0 right-0 w-32 h-32 bg-gradient-to-br ${topic.color} opacity-10 rounded-bl-full`} />
+            <span className="text-4xl mb-4 block">{topic.icon}</span>
+            <h3 className="text-lg font-semibold text-slate-800 group-hover:text-pink-600 transition-colors mb-2">
+              {topic.title}
+            </h3>
+            <div className="flex items-center gap-4 text-sm text-slate-500 mb-4">
+              <span className="flex items-center gap-1"><Clock className="w-4 h-4" /> {topic.duration}</span>
+              <span className="flex items-center gap-1"><BookOpen className="w-4 h-4" /> {topic.lessons} lessons</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="flex items-center gap-1 text-sm"><Star className="w-4 h-4 text-amber-500" /> {topic.rating}</span>
+              <span className="inline-flex items-center gap-1 text-pink-600 font-medium text-sm opacity-0 group-hover:opacity-100 transition-opacity">
+                Start <ArrowRight className="w-4 h-4" />
+              </span>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {/* Learning Path Preview */}
+      <div className="bg-white rounded-2xl p-8 shadow-lg border border-slate-200">
+        <h2 className="text-xl font-semibold text-slate-800 mb-6">What You'll Learn</h2>
+        <div className="grid md:grid-cols-2 gap-4">
+          {[
+            { icon: Code, text: "Core concepts and syntax" },
+            { icon: FileText, text: "Best practices and patterns" },
+            { icon: Video, text: "Video tutorials and examples" },
+            { icon: CheckCircle, text: "Hands-on exercises" },
+          ].map((item, idx) => (
+            <div key={idx} className="flex items-center gap-3 p-4 bg-slate-50 rounded-xl">
+              <item.icon className="w-5 h-5 text-pink-500" />
+              <span className="text-slate-700">{item.text}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/quiz/page.tsx
+++ b/app/dashboard/quiz/page.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import { useState } from "react"
+import { Brain, Trophy, Clock, Target, Play, CheckCircle, XCircle } from "lucide-react"
+
+const quizCategories = [
+  { id: "javascript", name: "JavaScript", icon: "🟨", questions: 50, color: "from-yellow-400 to-amber-500" },
+  { id: "react", name: "React", icon: "⚛️", questions: 40, color: "from-cyan-400 to-blue-500" },
+  { id: "python", name: "Python", icon: "🐍", questions: 45, color: "from-green-400 to-emerald-500" },
+  { id: "typescript", name: "TypeScript", icon: "🔷", questions: 35, color: "from-blue-400 to-indigo-500" },
+  { id: "css", name: "CSS", icon: "🎨", questions: 30, color: "from-pink-400 to-purple-500" },
+  { id: "nodejs", name: "Node.js", icon: "🟢", questions: 35, color: "from-lime-400 to-green-500" },
+]
+
+const recentQuizzes = [
+  { name: "JavaScript Basics", score: 85, total: 100, date: "2 days ago" },
+  { name: "React Hooks", score: 90, total: 100, date: "5 days ago" },
+  { name: "CSS Flexbox", score: 75, total: 100, date: "1 week ago" },
+]
+
+export default function QuizPage() {
+  const [selectedQuiz, setSelectedQuiz] = useState<string | null>(null)
+
+  return (
+    <div className="space-y-8 max-w-6xl mx-auto">
+      {/* Header */}
+      <div className="text-center space-y-4">
+        <div className="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-violet-100 to-purple-100 rounded-full">
+          <Brain className="w-5 h-5 text-violet-600" />
+          <span className="text-sm font-medium text-violet-700">Test Your Knowledge</span>
+        </div>
+        <h1 className="text-4xl font-bold bg-gradient-to-r from-violet-600 to-purple-600 bg-clip-text text-transparent">
+          Quiz Center
+        </h1>
+        <p className="text-slate-600 max-w-2xl mx-auto">
+          Challenge yourself with quizzes on various programming topics. 
+          Track your progress and improve your skills.
+        </p>
+      </div>
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="bg-white rounded-2xl p-6 shadow-lg border border-slate-200">
+          <Trophy className="w-8 h-8 text-amber-500 mb-3" />
+          <p className="text-2xl font-bold text-slate-800">1,250</p>
+          <p className="text-sm text-slate-500">Total Points</p>
+        </div>
+        <div className="bg-white rounded-2xl p-6 shadow-lg border border-slate-200">
+          <Target className="w-8 h-8 text-emerald-500 mb-3" />
+          <p className="text-2xl font-bold text-slate-800">83%</p>
+          <p className="text-sm text-slate-500">Avg. Score</p>
+        </div>
+        <div className="bg-white rounded-2xl p-6 shadow-lg border border-slate-200">
+          <CheckCircle className="w-8 h-8 text-blue-500 mb-3" />
+          <p className="text-2xl font-bold text-slate-800">24</p>
+          <p className="text-sm text-slate-500">Quizzes Completed</p>
+        </div>
+        <div className="bg-white rounded-2xl p-6 shadow-lg border border-slate-200">
+          <Clock className="w-8 h-8 text-purple-500 mb-3" />
+          <p className="text-2xl font-bold text-slate-800">5h 30m</p>
+          <p className="text-sm text-slate-500">Time Spent</p>
+        </div>
+      </div>
+
+      {/* Quiz Categories */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-slate-800">Choose a Topic</h2>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          {quizCategories.map((quiz) => (
+            <button
+              key={quiz.id}
+              onClick={() => setSelectedQuiz(quiz.id)}
+              className={`relative overflow-hidden bg-white rounded-2xl p-6 shadow-lg border-2 transition-all hover:shadow-xl hover:-translate-y-1 text-left group ${
+                selectedQuiz === quiz.id ? "border-violet-500" : "border-slate-200"
+              }`}
+            >
+              <div className={`absolute top-0 right-0 w-24 h-24 bg-gradient-to-br ${quiz.color} opacity-10 rounded-bl-full`} />
+              <span className="text-4xl mb-4 block">{quiz.icon}</span>
+              <h3 className="text-lg font-semibold text-slate-800 group-hover:text-violet-600 transition-colors">
+                {quiz.name}
+              </h3>
+              <p className="text-sm text-slate-500">{quiz.questions} questions</p>
+              <div className="mt-4 flex items-center gap-2 text-violet-600 font-medium text-sm opacity-0 group-hover:opacity-100 transition-opacity">
+                <Play className="w-4 h-4" /> Start Quiz
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Recent Quizzes */}
+      <div className="bg-white rounded-2xl p-6 shadow-lg border border-slate-200">
+        <h2 className="text-xl font-semibold text-slate-800 mb-4">Recent Activity</h2>
+        <div className="space-y-4">
+          {recentQuizzes.map((quiz, idx) => (
+            <div key={idx} className="flex items-center justify-between p-4 bg-slate-50 rounded-xl">
+              <div className="flex items-center gap-4">
+                <div className={`w-10 h-10 rounded-full flex items-center justify-center ${
+                  quiz.score >= 80 ? "bg-green-100" : quiz.score >= 60 ? "bg-yellow-100" : "bg-red-100"
+                }`}>
+                  {quiz.score >= 80 ? (
+                    <CheckCircle className="w-5 h-5 text-green-600" />
+                  ) : (
+                    <XCircle className="w-5 h-5 text-red-600" />
+                  )}
+                </div>
+                <div>
+                  <p className="font-medium text-slate-800">{quiz.name}</p>
+                  <p className="text-sm text-slate-500">{quiz.date}</p>
+                </div>
+              </div>
+              <div className="text-right">
+                <p className="text-lg font-bold text-slate-800">{quiz.score}%</p>
+                <p className="text-sm text-slate-500">{quiz.score}/{quiz.total}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/study-buddy/page.tsx
+++ b/app/dashboard/study-buddy/page.tsx
@@ -1,0 +1,126 @@
+"use client"
+
+import { useState } from "react"
+import { UserPlus, Users, MessageCircle, Video, Calendar, Search, Star, MapPin } from "lucide-react"
+
+const studyBuddies = [
+  {
+    name: "Emma Wilson",
+    avatar: "EW",
+    skills: ["React", "TypeScript", "Node.js"],
+    timezone: "PST (UTC-8)",
+    rating: 4.9,
+    sessions: 45,
+    status: "online"
+  },
+  {
+    name: "James Chen",
+    avatar: "JC",
+    skills: ["Python", "Machine Learning", "FastAPI"],
+    timezone: "EST (UTC-5)",
+    rating: 4.8,
+    sessions: 32,
+    status: "online"
+  },
+  {
+    name: "Sofia Garcia",
+    avatar: "SG",
+    skills: ["JavaScript", "Vue.js", "CSS"],
+    timezone: "CET (UTC+1)",
+    rating: 4.7,
+    sessions: 28,
+    status: "away"
+  },
+]
+
+export default function StudyBuddyPage() {
+  const [searchQuery, setSearchQuery] = useState("")
+
+  return (
+    <div className="space-y-8 max-w-6xl mx-auto">
+      {/* Header */}
+      <div className="text-center space-y-4">
+        <div className="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-purple-100 to-pink-100 rounded-full">
+          <UserPlus className="w-5 h-5 text-purple-600" />
+          <span className="text-sm font-medium text-purple-700">Find Learning Partners</span>
+        </div>
+        <h1 className="text-4xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
+          Study Buddy
+        </h1>
+        <p className="text-slate-600 max-w-2xl mx-auto">
+          Connect with fellow developers for pair programming, code reviews, and collaborative learning sessions.
+        </p>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-4">
+        <div className="bg-white rounded-2xl p-6 shadow-lg border border-slate-200 text-center">
+          <Users className="w-8 h-8 text-purple-500 mx-auto mb-2" />
+          <p className="text-2xl font-bold text-slate-800">2,450+</p>
+          <p className="text-sm text-slate-500">Active Members</p>
+        </div>
+        <div className="bg-white rounded-2xl p-6 shadow-lg border border-slate-200 text-center">
+          <Video className="w-8 h-8 text-pink-500 mx-auto mb-2" />
+          <p className="text-2xl font-bold text-slate-800">890</p>
+          <p className="text-sm text-slate-500">Sessions This Week</p>
+        </div>
+        <div className="bg-white rounded-2xl p-6 shadow-lg border border-slate-200 text-center">
+          <Calendar className="w-8 h-8 text-indigo-500 mx-auto mb-2" />
+          <p className="text-2xl font-bold text-slate-800">15k+</p>
+          <p className="text-sm text-slate-500">Total Sessions</p>
+        </div>
+      </div>
+
+      {/* Search */}
+      <div className="relative">
+        <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400" />
+        <input
+          type="text"
+          placeholder="Search by skills, name, or timezone..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="w-full pl-12 pr-4 py-4 bg-white border border-slate-200 rounded-2xl shadow-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent outline-none"
+        />
+      </div>
+
+      {/* Study Buddies List */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-slate-800">Available Study Buddies</h2>
+        <div className="grid md:grid-cols-3 gap-6">
+          {studyBuddies.map((buddy, idx) => (
+            <div key={idx} className="bg-white rounded-2xl p-6 shadow-lg border border-slate-200 hover:shadow-xl transition-all">
+              <div className="flex items-center gap-4 mb-4">
+                <div className="relative">
+                  <div className="w-14 h-14 rounded-full bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center text-white font-bold text-lg">
+                    {buddy.avatar}
+                  </div>
+                  <span className={`absolute bottom-0 right-0 w-4 h-4 rounded-full border-2 border-white ${
+                    buddy.status === "online" ? "bg-green-500" : "bg-yellow-500"
+                  }`} />
+                </div>
+                <div>
+                  <h3 className="font-semibold text-slate-800">{buddy.name}</h3>
+                  <div className="flex items-center gap-1 text-sm text-slate-500">
+                    <MapPin className="w-3 h-3" /> {buddy.timezone}
+                  </div>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2 mb-4">
+                {buddy.skills.map((skill) => (
+                  <span key={skill} className="px-2 py-1 bg-purple-50 text-purple-600 text-xs rounded-lg">{skill}</span>
+                ))}
+              </div>
+              <div className="flex items-center justify-between text-sm text-slate-500 mb-4">
+                <span className="flex items-center gap-1"><Star className="w-4 h-4 text-amber-500" /> {buddy.rating}</span>
+                <span>{buddy.sessions} sessions</span>
+              </div>
+              <button className="w-full py-3 bg-gradient-to-r from-purple-500 to-pink-500 text-white font-medium rounded-xl hover:shadow-lg transition-all flex items-center justify-center gap-2">
+                <MessageCircle className="w-4 h-4" /> Connect
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Fixes #161

This PR adds the missing dashboard route pages that were causing 404 errors when users clicked on sidebar items or quick action cards.

## Changes
- Add /dashboard/quiz - Quiz Center with quiz categories, stats, and recent activity
- Add /dashboard/forum - Community Forum with trending discussions and categories  
- Add /dashboard/projects - AI Project Recommender with skill level selection
- Add /dashboard/study-buddy - Study Buddy page to find learning partners
- Add /dashboard/quick-start - Quick Start page with curated learning topics

## Testing
All routes verified returning 200 status:
- \/dashboard\ 
- \/dashboard/quiz\ 
- \/dashboard/forum\ 
- \/dashboard/projects\ 
- \/dashboard/study-buddy\ 
- \/dashboard/quick-start\ 
- \/dashboard/resume\ 
- \/dashboard/notes\ 
- \/dashboard/calendar\ 

## Note
The 404 page already had proper navigation (Go Home, Go Back, Home Page buttons), so no changes were needed there.