### PR TITLE
Fix: Prevent Scroll-to-Top Button from Overlapping Footer Links (#300)

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -245,7 +245,7 @@ export default function Footer() {
           </div>
 
           {/* Newsletter Section */}
-          <div className="flex flex-col items-start">
+          <div className="flex flex-col items-start md:pr-8 lg:pr-16">
             <h4 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
               Stay Updated
             </h4>

--- a/app/components/ScrollToTop.tsx
+++ b/app/components/ScrollToTop.tsx
@@ -8,20 +8,28 @@ import { motion, AnimatePresence } from "framer-motion";
 export default function ScrollToTop() {
     const [isVisible, setIsVisible] = useState(false);
     const { announce } = useAccessibility();
+    const [isNearFooter, setIsNearFooter] = useState(false);
 
-    useEffect(() => {
-        const toggleVisibility = () => {
-            // Show button when page is scrolled down
-            if (window.scrollY > 300) {
-                setIsVisible(true);
-            } else {
-                setIsVisible(false);
-            }
-        };
+   useEffect(() => {
+    const handleScroll = () => {
+        const scrollY = window.scrollY;
+        const windowHeight = window.innerHeight;
+        const documentHeight = document.documentElement.scrollHeight;
 
-        window.addEventListener("scroll", toggleVisibility);
-        return () => window.removeEventListener("scroll", toggleVisibility);
-    }, []);
+        // Toggle visibility
+        setIsVisible(scrollY > 300);
+
+        // Detect if near footer (150px threshold)
+        if (scrollY + windowHeight >= documentHeight - 150) {
+            setIsNearFooter(true);
+        } else {
+            setIsNearFooter(false);
+        }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+}, []);
 
     const scrollToTop = () => {
         window.scrollTo({
@@ -39,8 +47,9 @@ export default function ScrollToTop() {
                     animate={{ opacity: 1, scale: 1 }}
                     exit={{ opacity: 0, scale: 0.5 }}
                     onClick={scrollToTop}
-                    className="fixed bottom-8 right-8 z-[50] p-3 bg-blue-600 hover:bg-blue-700 text-white rounded-full shadow-lg transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
-                    aria-label="Scroll to top"
+className={`fixed right-2 sm:right-3 md:right-4 lg:right-6 xl:right-8 z-[50] p-3 bg-blue-600 hover:bg-blue-700 text-white rounded-full shadow-lg transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 ${
+    isNearFooter ? "bottom-32" : "bottom-8"
+}`}        aria-label="Scroll to top"
                     whileHover={{ scale: 1.1 }}
                     whileTap={{ scale: 0.9 }}
                 >


### PR DESCRIPTION
## 🐛 Fix: Scroll-to-Top Button Overlaps Footer Legal Links (#300)

### 📌 Issue
The scroll-to-top button was overlapping footer content (Privacy / Terms links and Subscribe button) when the user reached the bottom of the page.

This affected readability and visual layout.

---

### ✅ Changes Made

- Added dynamic footer proximity detection.
- Adjusted vertical positioning when near footer.
- Improved responsive right alignment.
- Added spacing adjustment to the Stay Updated section.
- Ensured no overlap with footer links or newsletter button.

---

### 🎯 Result

- Scroll button no longer covers footer content.
- Layout remains clean and responsive.
- No impact on mobile behavior.
- Improved overall UX consistency.

---

### 📷 Before
Scroll button overlapping footer links.

### 📷 After
Scroll button repositions properly and maintains clean spacing.

---

### Screenshots
- Before
<img width="1919" height="485" alt="Screenshot 2026-02-24 120255" src="https://github.com/user-attachments/assets/f245ad59-c839-4c46-9f5f-f980dd24c024" />

- After
<img width="1919" height="387" alt="Screenshot 2026-02-24 120245" src="https://github.com/user-attachments/assets/5c658fe6-4c7c-4210-a636-c44065b99b7a" />

Closes #300