### PR TITLE
[GSSoC] fix: GET /api/user-stats/detailed missing rate limiting

### DIFF
--- a/__tests__/api/user-stats/detailed/route.test.ts
+++ b/__tests__/api/user-stats/detailed/route.test.ts
@@ -1,0 +1,84 @@
+import { auth } from '@clerk/nextjs/server';
+import { upstashLimit } from '@/lib/rate-limit-upstash';
+import { GET } from '@/app/api/user-stats/detailed/route';
+
+jest.mock('@clerk/nextjs/server', () => ({
+  auth: jest.fn(),
+}));
+
+const mockPrismaClient = {
+  quizAttempt: {
+    findMany: jest.fn(),
+  },
+  bookmark: {
+    findMany: jest.fn(),
+  },
+  userStats: {
+    findUnique: jest.fn(),
+  },
+};
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(() => mockPrismaClient),
+}));
+
+jest.mock('@/lib/rate-limit-upstash', () => ({
+  upstashLimit: jest.fn(),
+}));
+
+describe('GET /api/user-stats/detailed', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 429 when the request exceeds the rate limit', async () => {
+    (auth as jest.Mock).mockResolvedValue({ userId: 'user_123' });
+    (upstashLimit as jest.Mock).mockResolvedValue({
+      success: false,
+      remaining: 0,
+      reset: 1234567890,
+    });
+
+    const response = await GET();
+
+    expect(upstashLimit).toHaveBeenCalledWith('user_123:stats:detailed', {
+      maxRequests: 60,
+      windowMs: 60 * 1000,
+    });
+    expect(response.status).toBe(429);
+    expect(response.headers.get('X-RateLimit-Limit')).toBe('60');
+    expect(response.headers.get('X-RateLimit-Remaining')).toBe('0');
+    expect(response.headers.get('X-RateLimit-Reset')).toBe('1234567890');
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'Too many requests. Please slow down.',
+      resetAt: new Date(1234567890).toISOString(),
+    });
+    expect(mockPrismaClient.quizAttempt.findMany).not.toHaveBeenCalled();
+  });
+
+  it('returns detailed stats with rate limit headers when allowed', async () => {
+    (auth as jest.Mock).mockResolvedValue({ userId: 'user_123' });
+    (upstashLimit as jest.Mock).mockResolvedValue({
+      success: true,
+      remaining: 59,
+      reset: 1234567890,
+    });
+    mockPrismaClient.quizAttempt.findMany.mockResolvedValue([]);
+    mockPrismaClient.bookmark.findMany.mockResolvedValue([]);
+    mockPrismaClient.userStats.findUnique.mockResolvedValue({ currentStreak: 4 });
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-RateLimit-Limit')).toBe('60');
+    expect(response.headers.get('X-RateLimit-Remaining')).toBe('59');
+    expect(response.headers.get('X-RateLimit-Reset')).toBe('1234567890');
+    await expect(response.json()).resolves.toMatchObject({
+      insights: {
+        totalQuizzes: 0,
+        totalBookmarks: 0,
+        streakDays: 4,
+      },
+    });
+  });
+});

--- a/app/api/user-stats/detailed/route.ts
+++ b/app/api/user-stats/detailed/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
 import { PrismaClient } from '@prisma/client';
+import { upstashLimit } from '@/lib/rate-limit-upstash';
 
 // Singleton pattern for Prisma Client
 const globalForPrisma = global as unknown as { prisma: PrismaClient };
@@ -15,7 +16,27 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    // TODO: Add rate limiting back when path resolution is fixed
+    const rateLimitResult = await upstashLimit(userId + ':stats:detailed', {
+      maxRequests: 60,
+      windowMs: 60 * 1000,
+    });
+
+    if (!rateLimitResult.success) {
+      return NextResponse.json(
+        {
+          error: 'Too many requests. Please slow down.',
+          resetAt: new Date(rateLimitResult.reset).toISOString(),
+        },
+        {
+          status: 429,
+          headers: {
+            'X-RateLimit-Limit': '60',
+            'X-RateLimit-Remaining': '0',
+            'X-RateLimit-Reset': rateLimitResult.reset.toString(),
+          },
+        }
+      );
+    }
 
     // Get user activity over the last 30 days
     const thirtyDaysAgo = new Date();
@@ -147,7 +168,12 @@ export async function GET() {
       recentBookmarks,
       insights
     }, {
-      status: 200
+      status: 200,
+      headers: {
+        'X-RateLimit-Limit': '60',
+        'X-RateLimit-Remaining': rateLimitResult.remaining.toString(),
+        'X-RateLimit-Reset': rateLimitResult.reset.toString(),
+      },
     });
 
   } catch (error) {


### PR DESCRIPTION
The detailed stats handler now matches the regular stats route: it applies Upstash rate limiting per user, returns 429 when the limit is exceeded, and emits the X-RateLimit headers on both success and throttle responses. I also added a regression test in route.test.ts that covers both the allowed and blocked cases.

Static validation passed on the edited files, but I couldn’t run Jest in this workspace because the local binary is not available on PATH, so npm test fails with “jest is not recognized.” 


closes #312