### PR TITLE
[GSSoC] fix: Detailed per-route env validation is not guaranteed

### DIFF
--- a/__tests__/api/user-stats/detailed/route.test.ts
+++ b/__tests__/api/user-stats/detailed/route.test.ts
@@ -1,0 +1,84 @@
+import { auth } from '@clerk/nextjs/server';
+import { upstashLimit } from '@/lib/rate-limit-upstash';
+import { GET } from '@/app/api/user-stats/detailed/route';
+
+jest.mock('@clerk/nextjs/server', () => ({
+  auth: jest.fn(),
+}));
+
+const mockPrismaClient = {
+  quizAttempt: {
+    findMany: jest.fn(),
+  },
+  bookmark: {
+    findMany: jest.fn(),
+  },
+  userStats: {
+    findUnique: jest.fn(),
+  },
+};
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(() => mockPrismaClient),
+}));
+
+jest.mock('@/lib/rate-limit-upstash', () => ({
+  upstashLimit: jest.fn(),
+}));
+
+describe('GET /api/user-stats/detailed', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 429 when the request exceeds the rate limit', async () => {
+    (auth as jest.Mock).mockResolvedValue({ userId: 'user_123' });
+    (upstashLimit as jest.Mock).mockResolvedValue({
+      success: false,
+      remaining: 0,
+      reset: 1234567890,
+    });
+
+    const response = await GET();
+
+    expect(upstashLimit).toHaveBeenCalledWith('user_123:stats:detailed', {
+      maxRequests: 60,
+      windowMs: 60 * 1000,
+    });
+    expect(response.status).toBe(429);
+    expect(response.headers.get('X-RateLimit-Limit')).toBe('60');
+    expect(response.headers.get('X-RateLimit-Remaining')).toBe('0');
+    expect(response.headers.get('X-RateLimit-Reset')).toBe('1234567890');
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'Too many requests. Please slow down.',
+      resetAt: new Date(1234567890).toISOString(),
+    });
+    expect(mockPrismaClient.quizAttempt.findMany).not.toHaveBeenCalled();
+  });
+
+  it('returns detailed stats with rate limit headers when allowed', async () => {
+    (auth as jest.Mock).mockResolvedValue({ userId: 'user_123' });
+    (upstashLimit as jest.Mock).mockResolvedValue({
+      success: true,
+      remaining: 59,
+      reset: 1234567890,
+    });
+    mockPrismaClient.quizAttempt.findMany.mockResolvedValue([]);
+    mockPrismaClient.bookmark.findMany.mockResolvedValue([]);
+    mockPrismaClient.userStats.findUnique.mockResolvedValue({ currentStreak: 4 });
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-RateLimit-Limit')).toBe('60');
+    expect(response.headers.get('X-RateLimit-Remaining')).toBe('59');
+    expect(response.headers.get('X-RateLimit-Reset')).toBe('1234567890');
+    await expect(response.json()).resolves.toMatchObject({
+      insights: {
+        totalQuizzes: 0,
+        totalBookmarks: 0,
+        streakDays: 4,
+      },
+    });
+  });
+});

--- a/app/api/user-stats/detailed/route.ts
+++ b/app/api/user-stats/detailed/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
 import { PrismaClient } from '@prisma/client';
+import { upstashLimit } from '@/lib/rate-limit-upstash';
 
 // Singleton pattern for Prisma Client
 const globalForPrisma = global as unknown as { prisma: PrismaClient };
@@ -15,7 +16,27 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    // TODO: Add rate limiting back when path resolution is fixed
+    const rateLimitResult = await upstashLimit(userId + ':stats:detailed', {
+      maxRequests: 60,
+      windowMs: 60 * 1000,
+    });
+
+    if (!rateLimitResult.success) {
+      return NextResponse.json(
+        {
+          error: 'Too many requests. Please slow down.',
+          resetAt: new Date(rateLimitResult.reset).toISOString(),
+        },
+        {
+          status: 429,
+          headers: {
+            'X-RateLimit-Limit': '60',
+            'X-RateLimit-Remaining': '0',
+            'X-RateLimit-Reset': rateLimitResult.reset.toString(),
+          },
+        }
+      );
+    }
 
     // Get user activity over the last 30 days
     const thirtyDaysAgo = new Date();
@@ -147,7 +168,12 @@ export async function GET() {
       recentBookmarks,
       insights
     }, {
-      status: 200
+      status: 200,
+      headers: {
+        'X-RateLimit-Limit': '60',
+        'X-RateLimit-Remaining': rateLimitResult.remaining.toString(),
+        'X-RateLimit-Reset': rateLimitResult.reset.toString(),
+      },
     });
 
   } catch (error) {

--- a/lib/rate-limit-upstash.ts
+++ b/lib/rate-limit-upstash.ts
@@ -3,8 +3,11 @@ import { Redis } from '@upstash/redis';
 import type { Ratelimit as RatelimitClient } from '@upstash/ratelimit';
 import { Ratelimit } from '@upstash/ratelimit';
 import type { NextRequest } from 'next/server';
+import validateEnv from './env';
 
 let cached: { client?: any; limiter?: any } = {};
+
+if (process.env.NODE_ENV !== 'test') validateEnv();
 
 /**
  * Extracts the client IP address from a Next.js request


### PR DESCRIPTION
I moved the fail-fast check into the shared Upstash adapter so any server path that imports lib/rate-limit-upstash.ts now validates env immediately in non-test runtimes, instead of waiting until `upstashLimit()` throws a generic runtime error. That closes the gap left by middleware-only validation for routes that bypass that path.

closes #313