### PR TITLE
fix(navbar): resolve relative hash routing on sub-routes

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -17,9 +17,9 @@ import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
 
 export default function Navbar() {
   const navItems = [
-    { name: "Features", link: "#features" },
+    { name: "Features", link: "/#features" },
     { name: "Placement Arena", link: "/placement" },
-    { name: "Pricing", link: "#pricing" },
+    { name: "Pricing", link: "/#pricing" },
     { name: "About", link: "/about" },
   ];
 
@@ -72,14 +72,14 @@ export default function Navbar() {
           onClose={() => setIsMobileMenuOpen(false)}
         >
           {navItems.map((item, idx) => (
-            <a
+            <Link
               key={`mobile-link-${idx}`}
               href={item.link}
               onClick={() => setIsMobileMenuOpen(false)}
               className="relative text-gray-700 dark:text-gray-200 font-medium text-base hover:text-sky-600 dark:hover:text-sky-400 transition-colors py-2 w-full"
             >
               {item.name}
-            </a>
+            </Link>
           ))}
 
           {/* Mobile Auth Section */}


### PR DESCRIPTION
## What does this PR do?
This PR fixes a bug where the "Pricing" navigation link breaks and fails to route correctly when clicked from a sub-route (e.g., the `/about` page). 

It updates the configuration links to use absolute root paths (`/#pricing`) and wraps the dynamic menu map inside `Navbar.tsx` with Next.js's native client-side routing component (`Link`).

Closes #317

## Motivation
Previously, the component mapped menu links using raw standard HTML anchor tags with relative hashes (`#pricing`). When a user was on a sub-route like `/about`, the browser attempted to find that element ID locally (`/about#pricing`), breaking the navigation. Utilizing Next.js's client-side link optimization ensures proper cross-route hash reconciliation back to the homepage root.

## How to test
1. Run the project locally (`pnpm dev` or `npm run dev`).
2. Navigate away from the homepage by clicking **About** in the navbar to land on `/about`.
3. While on the About page, click **Pricing** in the navbar.
4. Verify that the browser seamlessly routes you back to the homepage and scrolls directly to the `#pricing` section, rather than sticking on `/about#pricing`.

## Checklist
- [x] I followed the contributing guide
- [ ] Tests added (if applicable)
- [x] Documentation updated (N/A)

If everything looks good, kindly merge this PR and add the required labels for gssoc'26. Thanks!