### PR TITLE
docs: fix seed and Upstash setup guidance (#333)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,9 @@ NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
 DATABASE_URL=
 # Direct connection to the database. Used for migrations
 DIRECT_URL=
+
+# Rate limiting
+# Use INMEM for local development if you do not have Upstash credentials yet.
+RATE_LIMIT_MODE=INMEM
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=

--- a/README.md
+++ b/README.md
@@ -194,6 +194,15 @@ You will need **two connection URLs** from Supabase:
 ```env
 DATABASE_URL="postgresql://postgres:<PASSWORD>@db.xxxxx.supabase.co:6543/postgres?pgbouncer=true"
 DIRECT_URL="postgresql://postgres:<PASSWORD>@db.xxxxx.supabase.co:5432/postgres"
+RATE_LIMIT_MODE="INMEM"
+```
+
+If you want to use the Redis-backed rate limiter instead of the local in-memory fallback, also add:
+
+```env
+RATE_LIMIT_MODE="UPSTASH"
+UPSTASH_REDIS_REST_URL="https://<your-upstash-endpoint>"
+UPSTASH_REDIS_REST_TOKEN="<your-upstash-token>"
 ```
 
 ### 4️⃣ Run Database Migrations
@@ -204,6 +213,9 @@ npx prisma generate
 
 # Push schema to database
 npx prisma db push
+
+# Seed the starter quiz/category data
+npx prisma db seed
 
 # (Optional) Open Prisma Studio for DB management
 npx prisma studio


### PR DESCRIPTION
## Summary
- document the rate-limit mode env contract in `.env.example`
- add the missing Upstash Redis environment variables to the setup template
- update the README setup flow to include Redis-backed rate limiting and the Prisma seed step

Fixes #333

## Verification
- git diff --check
- content spot-check for the new Upstash env keys and `npx prisma db seed` setup guidance