### PR TITLE
fix: initialize Upstash rate limiter per policy

### DIFF
--- a/__tests__/api/contact/route.test.ts
+++ b/__tests__/api/contact/route.test.ts
@@ -1,0 +1,62 @@
+import type { NextRequest } from 'next/server';
+import { upstashLimit } from '@/lib/rate-limit-upstash';
+
+let mockCreateContactSubmission = jest.fn();
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(() => {
+    mockCreateContactSubmission = jest.fn();
+    return {
+      contactSubmission: {
+        create: mockCreateContactSubmission,
+      },
+    };
+  }),
+}));
+
+jest.mock('@/lib/rate-limit-upstash', () => ({
+  getClientIP: jest.fn(() => '127.0.0.1'),
+  upstashLimit: jest.fn(),
+}));
+
+describe('POST /api/contact', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 429 and skips database writes when the rate limit is exceeded', async () => {
+    const { POST } = await import('@/app/api/contact/route');
+
+    (upstashLimit as jest.Mock).mockResolvedValue({
+      success: false,
+      remaining: 0,
+      reset: 1234567890,
+    });
+
+    const request = new Request('http://localhost/api/contact', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Verification',
+        email: 'verification@example.com',
+        message: 'Verify rate limiter',
+      }),
+    }) as unknown as NextRequest;
+
+    const response = await POST(request);
+
+    expect(upstashLimit).toHaveBeenCalledWith('127.0.0.1:contact', {
+      maxRequests: 5,
+      windowMs: 60 * 60 * 1000,
+    });
+    expect(response.status).toBe(429);
+    expect(response.headers.get('X-RateLimit-Limit')).toBe('5');
+    expect(response.headers.get('X-RateLimit-Remaining')).toBe('0');
+    expect(response.headers.get('X-RateLimit-Reset')).toBe('1234567890');
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'Too many requests. Please try again later.',
+      resetAt: new Date(1234567890).toISOString(),
+    });
+    expect(mockCreateContactSubmission).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/user-stats/detailed/route.test.ts
+++ b/__tests__/api/user-stats/detailed/route.test.ts
@@ -1,25 +1,37 @@
 import { auth } from '@clerk/nextjs/server';
 import { upstashLimit } from '@/lib/rate-limit-upstash';
-import { GET } from '@/app/api/user-stats/detailed/route';
 
 jest.mock('@clerk/nextjs/server', () => ({
   auth: jest.fn(),
 }));
 
-const mockPrismaClient = {
+let mockPrismaClient: {
   quizAttempt: {
-    findMany: jest.fn(),
-  },
+    findMany: jest.Mock;
+  };
   bookmark: {
-    findMany: jest.fn(),
-  },
+    findMany: jest.Mock;
+  };
   userStats: {
-    findUnique: jest.fn(),
-  },
+    findUnique: jest.Mock;
+  };
 };
 
 jest.mock('@prisma/client', () => ({
-  PrismaClient: jest.fn(() => mockPrismaClient),
+  PrismaClient: jest.fn(() => {
+    mockPrismaClient = {
+      quizAttempt: {
+        findMany: jest.fn(),
+      },
+      bookmark: {
+        findMany: jest.fn(),
+      },
+      userStats: {
+        findUnique: jest.fn(),
+      },
+    };
+    return mockPrismaClient;
+  }),
 }));
 
 jest.mock('@/lib/rate-limit-upstash', () => ({
@@ -32,7 +44,9 @@ describe('GET /api/user-stats/detailed', () => {
   });
 
   it('returns 429 when the request exceeds the rate limit', async () => {
-    (auth as jest.Mock).mockResolvedValue({ userId: 'user_123' });
+    const { GET } = await import('@/app/api/user-stats/detailed/route');
+
+    (auth as unknown as jest.Mock).mockResolvedValue({ userId: 'user_123' });
     (upstashLimit as jest.Mock).mockResolvedValue({
       success: false,
       remaining: 0,
@@ -57,7 +71,9 @@ describe('GET /api/user-stats/detailed', () => {
   });
 
   it('returns detailed stats with rate limit headers when allowed', async () => {
-    (auth as jest.Mock).mockResolvedValue({ userId: 'user_123' });
+    const { GET } = await import('@/app/api/user-stats/detailed/route');
+
+    (auth as unknown as jest.Mock).mockResolvedValue({ userId: 'user_123' });
     (upstashLimit as jest.Mock).mockResolvedValue({
       success: true,
       remaining: 59,

--- a/__tests__/lib/env.test.ts
+++ b/__tests__/lib/env.test.ts
@@ -28,7 +28,7 @@ describe('env validation', () => {
   });
 
   test('requires DATABASE_URL and CLERK_SECRET_KEY in production', () => {
-    process.env.NODE_ENV = 'production';
+    Object.assign(process.env, { NODE_ENV: 'production' });
     delete process.env.DATABASE_URL;
     delete process.env.CLERK_SECRET_KEY;
 
@@ -43,7 +43,7 @@ describe('env validation', () => {
   });
 
   test('returns typed env when everything is provided', () => {
-    process.env.NODE_ENV = 'production';
+    Object.assign(process.env, { NODE_ENV: 'production' });
     process.env.DATABASE_URL = 'postgresql://user:pass@localhost/testdb';
     process.env.CLERK_SECRET_KEY = 'secret';
     process.env.RATE_LIMIT_MODE = 'INMEM';

--- a/__tests__/lib/rate-limit-upstash.mock.test.ts
+++ b/__tests__/lib/rate-limit-upstash.mock.test.ts
@@ -1,26 +1,51 @@
-import { upstashLimit } from '../../lib/rate-limit-upstash';
-
-const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
-const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
-// Ensure env vars are set for the adapter to initialize (mocked services will be used)
-process.env.UPSTASH_REDIS_REST_URL = process.env.UPSTASH_REDIS_REST_URL || 'http://localhost';
-process.env.UPSTASH_REDIS_REST_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN || 'test-token';
+const mockLimit = jest.fn();
 
 jest.mock('@upstash/redis', () => ({
-  Redis: jest.fn().mockImplementation(() => ({})),
-}), { virtual: true });
+  Redis: jest.fn().mockImplementation((config: { url: string; token: string }) => ({
+    config,
+  })),
+}));
 
 jest.mock('@upstash/ratelimit', () => {
-  const slidingWindow = jest.fn().mockImplementation((_max: number, _win: string) => ({}));
-  const Ratelimit = jest.fn().mockImplementation(() => ({
-    limit: async (_id: string) => ({ success: true, remaining: 2, resetAfter: 10000 }),
+  const slidingWindow = jest.fn((tokens: number, window: string) => ({
+    tokens,
+    window,
   }));
-  // Attach static helper
-  (Ratelimit as any).slidingWindow = slidingWindow;
+
+  const Ratelimit = jest.fn().mockImplementation((config: unknown) => ({
+    config,
+    limit: mockLimit,
+  }));
+
+  Object.assign(Ratelimit, { slidingWindow });
+
   return { Ratelimit };
-}, { virtual: true });
+});
+
+import { Redis } from '@upstash/redis';
+import { Ratelimit } from '@upstash/ratelimit';
+import { __resetUpstashLimitCacheForTests, upstashLimit } from '../../lib/rate-limit-upstash';
+
+const mockRatelimit = Ratelimit as unknown as jest.Mock;
+const mockSlidingWindow = Ratelimit.slidingWindow as unknown as jest.Mock;
+const mockRedis = Redis as unknown as jest.Mock;
 
 describe('Upstash adapter (mocked)', () => {
+  const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+  const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetUpstashLimitCacheForTests();
+    process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    mockLimit.mockResolvedValue({
+      success: true,
+      remaining: 2,
+      reset: 1234567890,
+    });
+  });
+
   afterAll(() => {
     if (originalUrl === undefined) {
       delete process.env.UPSTASH_REDIS_REST_URL;
@@ -35,10 +60,61 @@ describe('Upstash adapter (mocked)', () => {
     }
   });
 
-  it('returns mapped rate limit result', async () => {
+  it('initializes the Upstash SDK with a limiter algorithm', async () => {
     const res = await upstashLimit('test-id', { maxRequests: 5, windowMs: 60 * 60 * 1000 });
-    expect(res.success).toBe(true);
-    expect(typeof res.remaining).toBe('number');
-    expect(typeof res.reset).toBe('number');
+
+    expect(res).toEqual({
+      success: true,
+      remaining: 2,
+      reset: 1234567890,
+    });
+    expect(mockRedis).toHaveBeenCalledWith({
+      url: 'https://upstash.example',
+      token: 'test-token',
+    });
+    expect(mockSlidingWindow).toHaveBeenCalledWith(5, '3600 s');
+
+    const constructorConfig = mockRatelimit.mock.calls[0][0];
+    expect(constructorConfig).toMatchObject({
+      redis: expect.objectContaining({
+        config: {
+          url: 'https://upstash.example',
+          token: 'test-token',
+        },
+      }),
+      limiter: { tokens: 5, window: '3600 s' },
+    });
+    expect(constructorConfig).not.toHaveProperty('slidingWindow');
+    expect(constructorConfig).not.toHaveProperty('limit');
+  });
+
+  it('reuses the limiter for the same policy without crashing', async () => {
+    await upstashLimit('first-id', { maxRequests: 5, windowMs: 60 * 60 * 1000 });
+    await upstashLimit('second-id', { maxRequests: 5, windowMs: 60 * 60 * 1000 });
+
+    expect(mockRatelimit).toHaveBeenCalledTimes(1);
+    expect(mockSlidingWindow).toHaveBeenCalledTimes(1);
+    expect(mockLimit).toHaveBeenNthCalledWith(1, 'first-id');
+    expect(mockLimit).toHaveBeenNthCalledWith(2, 'second-id');
+  });
+
+  it('caches independent limiters for different policies', async () => {
+    await upstashLimit('newsletter-id', { maxRequests: 3, windowMs: 60 * 60 * 1000 });
+    await upstashLimit('contact-id', { maxRequests: 5, windowMs: 60 * 60 * 1000 });
+    await upstashLimit('stats-id', { maxRequests: 60, windowMs: 60 * 1000 });
+    await upstashLimit('newsletter-id-again', { maxRequests: 3, windowMs: 60 * 60 * 1000 });
+
+    expect(mockRatelimit).toHaveBeenCalledTimes(3);
+    expect(mockSlidingWindow).toHaveBeenNthCalledWith(1, 3, '3600 s');
+    expect(mockSlidingWindow).toHaveBeenNthCalledWith(2, 5, '3600 s');
+    expect(mockSlidingWindow).toHaveBeenNthCalledWith(3, 60, '60 s');
+  });
+
+  it('throws a descriptive error when Upstash credentials are missing', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+
+    await expect(
+      upstashLimit('test-id', { maxRequests: 5, windowMs: 60 * 60 * 1000 })
+    ).rejects.toThrow('Missing Upstash configuration');
   });
 });

--- a/lib/rate-limit-upstash.ts
+++ b/lib/rate-limit-upstash.ts
@@ -54,8 +54,8 @@ export async function upstashLimit(identifier: string, config: RateLimitConfig):
     });
   }
 
-  const windowSeconds = Math.max(1, Math.floor(config.windowMs / 1000));
-  const policyKey = `${config.maxRequests}:${windowSeconds}`;
+  const windowSeconds = Math.max(1, Math.ceil(config.windowMs / 1000));
+  const policyKey = `${config.maxRequests}:${config.windowMs}:${windowSeconds}`;
   let limiter = limiterCache.get(policyKey);
 
   if (!limiter) {

--- a/lib/rate-limit-upstash.ts
+++ b/lib/rate-limit-upstash.ts
@@ -1,11 +1,16 @@
 import type { RateLimitConfig, RateLimitResult } from './rate-limit';
 import { Redis } from '@upstash/redis';
-import type { Ratelimit as RatelimitClient } from '@upstash/ratelimit';
 import { Ratelimit } from '@upstash/ratelimit';
 import type { NextRequest } from 'next/server';
 import validateEnv from './env';
 
-let cached: { client?: any; limiter?: any } = {};
+type RedisClient = InstanceType<typeof Redis>;
+type UpstashLimiter = InstanceType<typeof Ratelimit>;
+
+const MAX_CACHED_POLICIES = 50;
+
+let redisClient: RedisClient | undefined;
+const limiterCache = new Map<string, UpstashLimiter>();
 
 if (process.env.NODE_ENV !== 'test') validateEnv();
 
@@ -42,31 +47,41 @@ export async function upstashLimit(identifier: string, config: RateLimitConfig):
     throw new Error('Missing Upstash configuration');
   }
 
-  if (!cached.limiter) {
-    const client = new Redis({
+  if (!redisClient) {
+    redisClient = new Redis({
       url: process.env.UPSTASH_REDIS_REST_URL,
       token: process.env.UPSTASH_REDIS_REST_TOKEN,
     });
-
-    const limiter = new Ratelimit({
-      redis: client,
-      // sliding window expects a string like "60s"; convert from ms
-      slidingWindow: Math.max(1, Math.floor(config.windowMs / 1000)) + 's',
-      limit: config.maxRequests,
-    } as any) as unknown as RatelimitClient;
-
-    cached = { client, limiter };
   }
 
-  const res = await cached.limiter.limit(identifier);
+  const windowSeconds = Math.max(1, Math.floor(config.windowMs / 1000));
+  const policyKey = `${config.maxRequests}:${windowSeconds}`;
+  let limiter = limiterCache.get(policyKey);
 
-  // map upstash result to RateLimitResult
-  const now = Date.now();
-  const resetAfter = (res.resetAfter && typeof res.resetAfter === 'number') ? res.resetAfter : 0;
+  if (!limiter) {
+    limiter = new Ratelimit({
+      redis: redisClient,
+      limiter: Ratelimit.slidingWindow(config.maxRequests, `${windowSeconds} s`),
+    });
+
+    if (limiterCache.size >= MAX_CACHED_POLICIES) {
+      const oldestKey = limiterCache.keys().next().value;
+      if (oldestKey) limiterCache.delete(oldestKey);
+    }
+
+    limiterCache.set(policyKey, limiter);
+  }
+
+  const res = await limiter.limit(identifier);
 
   return {
-    success: !!res.success,
-    remaining: typeof res.remaining === 'number' ? res.remaining : 0,
-    reset: now + resetAfter,
+    success: res.success,
+    remaining: res.remaining,
+    reset: res.reset,
   };
+}
+
+export function __resetUpstashLimitCacheForTests(): void {
+  redisClient = undefined;
+  limiterCache.clear();
 }


### PR DESCRIPTION
solves issue #340 
## 📌 Description

This PR fixes the shared Upstash rate-limiting adapter implementation in
`lib/rate-limit-upstash.ts`.

The existing implementation initializes `@upstash/ratelimit` using an
invalid configuration shape:

```ts id="dg28wo"
const limiter = new Ratelimit({
  redis: client,
  slidingWindow: Math.max(1, Math.floor(config.windowMs / 1000)) + 's',
  limit: config.maxRequests,
} as any);
```

However, recent versions of `@upstash/ratelimit` expect the limiter strategy
to be created through helper methods such as `Ratelimit.slidingWindow(...)`
instead of passing `slidingWindow` and `limit` directly into the constructor.

Because of this, protected API routes crash at runtime when the limiter is
executed, producing errors similar to:

```txt id="rjlwmz"
TypeError: this.limiter is not a function
```

## 🔍 Root Cause

The adapter attempts to construct the rate limiter with unsupported
constructor fields:

* `slidingWindow`
* `limit`

These values are ignored internally, resulting in an improperly initialized
limiter instance.

Additionally, the current singleton caching approach is unsafe for routes that
use different rate-limit configurations. Since the same limiter instance may
be reused across multiple API routes, quotas can unintentionally leak between
routes with different limits or windows.

## ✅ Changes Made

* Replaced the invalid constructor configuration with the official
  `Ratelimit.slidingWindow(...)` strategy API
* Fixed runtime crashes caused by invalid limiter initialization
* Updated adapter logic to correctly support configurable rate limits
* Improved singleton handling to avoid cross-route quota conflicts
* Removed reliance on `as any` type casting for invalid configuration bypasses
* Ensured compatibility with current versions of `@upstash/ratelimit`

## 🧪 Expected Result

After this change:

* Protected API routes no longer crash when Upstash rate limiting is enabled
* Rate limits are applied correctly per route configuration
* Different API routes can safely use different quotas/windows
* The adapter works as intended with the official Upstash API
