### PR TITLE
fix: point footer GitHub icon to project repo (#337)

### DIFF
--- a/__tests__/app/footer.social-links.test.tsx
+++ b/__tests__/app/footer.social-links.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import Footer from "@/app/components/Footer";
+
+jest.mock("next/link", () => {
+  return ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+});
+
+jest.mock("@/lib/toast", () => ({
+  showSuccess: jest.fn(),
+  showError: jest.fn(),
+}));
+
+describe("Footer social links", () => {
+  it("points the GitHub icon to the project repository", () => {
+    render(<Footer />);
+
+    const githubLink = screen.getByRole("link", { name: /github/i });
+
+    expect(githubLink).toHaveAttribute(
+      "href",
+      "https://github.com/Darshan3690/The-Dev-Pocket",
+    );
+  });
+});

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -107,7 +107,7 @@ export default function Footer() {
                 <FaLinkedin className="w-4 h-4" />
               </a>
               <a
-                href="https://github.com"
+                href="https://github.com/Darshan3690/The-Dev-Pocket"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="p-2 bg-white dark:bg-gray-800 rounded-lg hover:bg-gray-700 hover:text-white dark:hover:bg-gray-600 transition-all duration-200 shadow-sm hover:shadow-md transform hover:-translate-y-1"


### PR DESCRIPTION
## Summary
- replace the footer GitHub icon placeholder link with the actual project repository URL
- add a focused footer regression test for the GitHub social link target

## Verification
- npm.cmd test -- --runTestsByPath __tests__/app/footer.social-links.test.tsx --runInBand

Fixes #337