### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## What does this PR do?
+Short description of the changes.
+
+## Motivation
+Why is this change needed? What problem does it solve?
+
+## How to test
+Steps to verify the change works correctly.
+
+## Checklist
+- [ ] I followed the contributing guidelines
+- [ ] Tests added or updated (if applicable)
+- [ ] Documentation updated (if applicable)
+- [ ] Code compiles without errors
+- [ ] No sensitive data committed


### PR DESCRIPTION
## Summary
- Added `.github/PULL_REQUEST_TEMPLATE.md` to guide contributors on writing good PR descriptions.

## Problem
The repository lacks a pull request template, leading to low-quality or incomplete PR descriptions that make review harder.

## Evidence
Issue #356 explicitly requests adding a PR template. CONTRIBUTING.md references PR templates but none exist.

## Solution
Created `.github/PULL_REQUEST_TEMPLATE.md` with sections for: What does this PR do, Motivation, How to test, and Checklist. Also noted that existing issue templates (`.github/ISSUE_TEMPLATE/`) already exist and were not modified.

## Tests / Validation
- Verified file exists at correct path: `.github/PULL_REQUEST_TEMPLATE.md`
- Verified it follows GitHub's expected template format
- Did not modify existing issue templates

## Risk / Compatibility
Docs/tooling only — no code changes, no runtime impact.

## Notes for maintainers
- Existing issue templates (`bug_report.md`, `custom.md`, `feature_request.md`) were left unchanged
- Template format follows GitHub best practices