### PR TITLE
docs: fix incorrect clerk publishable key environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ npx prisma studio
 4. 📝 Add to `.env.local`:
 
 ```env
-CLERK_PUBLISHABLE_KEY=your_publishable_key
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=your_publishable_key
 CLERK_SECRET_KEY=your_secret_key
 ```
 


### PR DESCRIPTION
Description:

This PR fixes a critical typo in the local setup instructions for Clerk authentication. The environment variable for the publishable key was listed as CLERK_PUBLISHABLE_KEY. In Next.js, this prevents the variable from being exposed to the frontend, causing the application to crash on startup for new contributors. I updated the documentation to use the required NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY format so the app runs successfully locally.  

Closes #None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the authentication setup instructions to use the correct public key environment variable in the example configuration.
  * Clarified the environment variable naming expected for Clerk integration while keeping the secret key example unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->