### PR TITLE
feat: Weekly Dev Digest Email Subscription (#400)

### DIFF
--- a/__tests__/lib/digest.test.ts
+++ b/__tests__/lib/digest.test.ts
@@ -1,0 +1,69 @@
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    resource: {
+      findMany: jest.fn(),
+    },
+    digestSubscription: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      upsert: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/lib/prisma';
+import { buildDigestContent, renderDigestEmail, DIGEST_SECTIONS, DIGEST_FREQUENCIES } from '@/lib/digest';
+
+describe('digest content builder', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('exposes the expected section and frequency options', () => {
+    expect(DIGEST_SECTIONS).toEqual(['new_resources', 'top_picks', 'community_highlights']);
+    expect(DIGEST_FREQUENCIES).toEqual(['weekly', 'biweekly']);
+  });
+
+  it('only fetches sections that were requested', async () => {
+    (prisma.resource.findMany as jest.Mock).mockResolvedValue([]);
+
+    await buildDigestContent(['new_resources'], 'weekly', null);
+
+    expect(prisma.resource.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches all three sections when all are requested', async () => {
+    (prisma.resource.findMany as jest.Mock).mockResolvedValue([]);
+
+    await buildDigestContent(['new_resources', 'top_picks', 'community_highlights'], 'weekly', null);
+
+    expect(prisma.resource.findMany).toHaveBeenCalledTimes(3);
+  });
+
+  it('applies the difficulty filter to each section query', async () => {
+    (prisma.resource.findMany as jest.Mock).mockResolvedValue([]);
+
+    await buildDigestContent(['new_resources'], 'weekly', 'beginner');
+
+    const call = (prisma.resource.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.difficulty).toBe('beginner');
+  });
+
+  it('renders only sections with content', () => {
+    const html = renderDigestEmail(
+      {
+        periodStart: new Date().toISOString(),
+        periodEnd: new Date().toISOString(),
+        newResources: [{ id: '1', title: 'Test', url: 'https://example.com', category: 'article', difficulty: 'beginner' }],
+        topPicks: [],
+        communityHighlights: [],
+      },
+      'https://example.com/unsubscribe?token=abc'
+    );
+
+    expect(html).toContain('New This Week');
+    expect(html).not.toContain('Top Picks');
+    expect(html).toContain('unsubscribe?token=abc');
+  });
+});

--- a/app/api/digest/preferences/route.ts
+++ b/app/api/digest/preferences/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { auth, clerkClient } from '@clerk/nextjs/server';
+import { DIGEST_SECTIONS, DIGEST_FREQUENCIES } from '@/lib/digest';
+
+const DIFFICULTIES = ['beginner', 'intermediate', 'advanced'];
+
+export async function GET() {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const subscription = await prisma.digestSubscription.findUnique({ where: { userId } });
+
+    return NextResponse.json({ subscription });
+  } catch (error) {
+    console.error('Error fetching digest preferences:', error);
+    return NextResponse.json({ error: 'Failed to fetch preferences' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { frequency, sections, difficultyFilter } = body;
+
+    if (!DIGEST_FREQUENCIES.includes(frequency)) {
+      return NextResponse.json(
+        { error: `frequency must be one of: ${DIGEST_FREQUENCIES.join(', ')}` },
+        { status: 400 }
+      );
+    }
+
+    if (!Array.isArray(sections) || sections.length === 0 || !sections.every((s) => DIGEST_SECTIONS.includes(s))) {
+      return NextResponse.json(
+        { error: `sections must be a non-empty array from: ${DIGEST_SECTIONS.join(', ')}` },
+        { status: 400 }
+      );
+    }
+
+    if (difficultyFilter && !DIFFICULTIES.includes(difficultyFilter)) {
+      return NextResponse.json(
+        { error: `difficultyFilter must be one of: ${DIFFICULTIES.join(', ')}` },
+        { status: 400 }
+      );
+    }
+
+    const client = await clerkClient();
+    const user = await client.users.getUser(userId);
+    const email = user.primaryEmailAddress?.emailAddress;
+
+    if (!email) {
+      return NextResponse.json({ error: 'No verified email found on your account' }, { status: 400 });
+    }
+
+    const subscription = await prisma.digestSubscription.upsert({
+      where: { userId },
+      create: {
+        userId,
+        email,
+        frequency,
+        sections,
+        difficultyFilter: difficultyFilter || null,
+        isActive: true,
+      },
+      update: {
+        email,
+        frequency,
+        sections,
+        difficultyFilter: difficultyFilter || null,
+        isActive: true,
+      },
+    });
+
+    return NextResponse.json({ subscription });
+  } catch (error) {
+    console.error('Error saving digest preferences:', error);
+    return NextResponse.json({ error: 'Failed to save preferences' }, { status: 500 });
+  }
+}

--- a/app/api/digest/preview/route.ts
+++ b/app/api/digest/preview/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { buildDigestContent, DIGEST_SECTIONS, DIGEST_FREQUENCIES, DigestSection, DigestFrequency } from '@/lib/digest';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const sectionsParam = searchParams.get('sections');
+    const frequencyParam = searchParams.get('frequency') || 'weekly';
+    const difficultyFilter = searchParams.get('difficulty');
+
+    const sections = (sectionsParam ? sectionsParam.split(',') : [...DIGEST_SECTIONS]).filter((s) =>
+      DIGEST_SECTIONS.includes(s as DigestSection)
+    ) as DigestSection[];
+
+    if (!DIGEST_FREQUENCIES.includes(frequencyParam as DigestFrequency)) {
+      return NextResponse.json(
+        { error: `frequency must be one of: ${DIGEST_FREQUENCIES.join(', ')}` },
+        { status: 400 }
+      );
+    }
+
+    const content = await buildDigestContent(sections, frequencyParam as DigestFrequency, difficultyFilter);
+
+    return NextResponse.json({ content });
+  } catch (error) {
+    console.error('Error building digest preview:', error);
+    return NextResponse.json({ error: 'Failed to build preview' }, { status: 500 });
+  }
+}

--- a/app/api/digest/send/route.ts
+++ b/app/api/digest/send/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { buildDigestContent, renderDigestEmail, DigestFrequency, DigestSection } from '@/lib/digest';
+import { sendEmail } from '@/lib/email';
+
+const FREQUENCY_INTERVAL_MS: Record<DigestFrequency, number> = {
+  weekly: 7 * 24 * 60 * 60 * 1000,
+  biweekly: 14 * 24 * 60 * 60 * 1000,
+};
+
+// Triggered on a schedule (e.g. Vercel Cron hitting this route weekly) with a
+// shared secret, since this app has no background job runner.
+export async function POST(request: NextRequest) {
+  const secret = request.headers.get('x-cron-secret');
+  if (!process.env.CRON_SECRET || secret !== process.env.CRON_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const subscriptions = await prisma.digestSubscription.findMany({
+      where: { isActive: true },
+    });
+
+    const now = Date.now();
+    let sentCount = 0;
+
+    for (const sub of subscriptions) {
+      const interval = FREQUENCY_INTERVAL_MS[sub.frequency as DigestFrequency];
+      const dueAt = sub.lastSentAt ? new Date(sub.lastSentAt).getTime() + interval : 0;
+
+      if (now < dueAt) continue;
+
+      const content = await buildDigestContent(
+        sub.sections as DigestSection[],
+        sub.frequency as DigestFrequency,
+        sub.difficultyFilter
+      );
+
+      const unsubscribeUrl = `${process.env.NEXT_PUBLIC_APP_URL || ''}/api/digest/unsubscribe?token=${sub.unsubscribeToken}`;
+      const html = renderDigestEmail(content, unsubscribeUrl);
+
+      await sendEmail({
+        to: sub.email,
+        subject: `Your Dev Pocket Digest - Week of ${new Date().toLocaleDateString()}`,
+        html,
+      });
+
+      await prisma.digestSubscription.update({
+        where: { id: sub.id },
+        data: { lastSentAt: new Date() },
+      });
+
+      sentCount += 1;
+    }
+
+    return NextResponse.json({ sentCount });
+  } catch (error) {
+    console.error('Error sending digest emails:', error);
+    return NextResponse.json({ error: 'Failed to send digest emails' }, { status: 500 });
+  }
+}

--- a/app/api/digest/unsubscribe/route.ts
+++ b/app/api/digest/unsubscribe/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const token = searchParams.get('token');
+
+    if (!token) {
+      return NextResponse.json({ error: 'Missing token' }, { status: 400 });
+    }
+
+    const subscription = await prisma.digestSubscription.findUnique({
+      where: { unsubscribeToken: token },
+    });
+
+    if (!subscription) {
+      return NextResponse.json({ error: 'Invalid or expired unsubscribe link' }, { status: 404 });
+    }
+
+    if (!subscription.isActive) {
+      return NextResponse.json({ message: 'Already unsubscribed' }, { status: 200 });
+    }
+
+    await prisma.digestSubscription.update({
+      where: { unsubscribeToken: token },
+      data: { isActive: false },
+    });
+
+    return NextResponse.json({ message: 'Successfully unsubscribed from the weekly digest' }, { status: 200 });
+  } catch (error) {
+    console.error('Error unsubscribing from digest:', error);
+    return NextResponse.json({ error: 'Failed to unsubscribe' }, { status: 500 });
+  }
+}

--- a/app/settings/[[...rest]]/page.tsx
+++ b/app/settings/[[...rest]]/page.tsx
@@ -7,6 +7,7 @@ import { BookOpen, UserCircle, Loader2 } from "lucide-react";
 import { showSuccess, showError } from "@/lib/toast";
 import ProfileCard from "@/components/profile/ProfileCard";
 import ProfileForm from "@/components/profile/ProfileForm";
+import DigestPreferences from "@/components/digest/DigestPreferences";
 import { ProfileFormData } from "@/lib/types/profile";
 
 const SettingsPage = () => {
@@ -203,6 +204,16 @@ const SettingsPage = () => {
               </p>
             </div>
           </div>
+        </div>
+      </div>
+
+      {/* Weekly Digest Preferences */}
+      <div className="mb-8">
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+          Weekly Digest
+        </h2>
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 p-6">
+          <DigestPreferences />
         </div>
       </div>
 

--- a/components/digest/DigestPreferences.tsx
+++ b/components/digest/DigestPreferences.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const SECTION_OPTIONS = [
+  { value: 'new_resources', label: 'New Resources' },
+  { value: 'top_picks', label: 'Top Picks' },
+  { value: 'community_highlights', label: 'Community Highlights' },
+];
+
+const FREQUENCY_OPTIONS = [
+  { value: 'weekly', label: 'Weekly (Sunday)' },
+  { value: 'biweekly', label: 'Bi-weekly' },
+];
+
+const DIFFICULTY_OPTIONS = ['', 'beginner', 'intermediate', 'advanced'];
+
+interface PreviewContent {
+  newResources: Array<{ id: string; title: string; url: string }>;
+  topPicks: Array<{ id: string; title: string; url: string }>;
+  communityHighlights: Array<{ id: string; title: string; url: string }>;
+}
+
+export default function DigestPreferences() {
+  const [frequency, setFrequency] = useState('weekly');
+  const [sections, setSections] = useState<string[]>(['new_resources', 'top_picks']);
+  const [difficultyFilter, setDifficultyFilter] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState('');
+  const [preview, setPreview] = useState<PreviewContent | null>(null);
+  const [loadingPreview, setLoadingPreview] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const res = await fetch('/api/digest/preferences');
+      if (res.ok) {
+        const data = await res.json();
+        if (data.subscription) {
+          setFrequency(data.subscription.frequency);
+          setSections(data.subscription.sections);
+          setDifficultyFilter(data.subscription.difficultyFilter || '');
+        }
+      }
+    })();
+  }, []);
+
+  const toggleSection = (value: string) => {
+    setSections((prev) => (prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value]));
+  };
+
+  const loadPreview = async () => {
+    setLoadingPreview(true);
+    try {
+      const params = new URLSearchParams({
+        sections: sections.join(','),
+        frequency,
+        ...(difficultyFilter ? { difficulty: difficultyFilter } : {}),
+      });
+      const res = await fetch(`/api/digest/preview?${params.toString()}`);
+      if (res.ok) {
+        const data = await res.json();
+        setPreview(data.content);
+      }
+    } finally {
+      setLoadingPreview(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setMessage('');
+    try {
+      const res = await fetch('/api/digest/preferences', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ frequency, sections, difficultyFilter: difficultyFilter || undefined }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        setMessage(data.error || 'Failed to save preferences');
+        return;
+      }
+
+      setMessage('Digest preferences saved!');
+    } catch {
+      setMessage('Failed to save preferences. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="font-semibold mb-2">Digest Frequency</h3>
+        <div className="flex gap-3">
+          {FREQUENCY_OPTIONS.map((opt) => (
+            <label key={opt.value} className="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                name="frequency"
+                value={opt.value}
+                checked={frequency === opt.value}
+                onChange={() => setFrequency(opt.value)}
+              />
+              {opt.label}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <h3 className="font-semibold mb-2">Content Sections</h3>
+        <div className="flex flex-col gap-2">
+          {SECTION_OPTIONS.map((opt) => (
+            <label key={opt.value} className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={sections.includes(opt.value)}
+                onChange={() => toggleSection(opt.value)}
+              />
+              {opt.label}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <h3 className="font-semibold mb-2">Difficulty Filter</h3>
+        <select
+          value={difficultyFilter}
+          onChange={(e) => setDifficultyFilter(e.target.value)}
+          className="flex h-10 items-center rounded-md border border-input bg-background px-3 py-2 text-sm"
+        >
+          {DIFFICULTY_OPTIONS.map((d) => (
+            <option key={d} value={d}>
+              {d === '' ? 'All levels' : d.charAt(0).toUpperCase() + d.slice(1)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={handleSave}
+          disabled={saving || sections.length === 0}
+          className="px-4 py-2 rounded-md bg-blue-600 text-white text-sm font-medium disabled:opacity-50"
+        >
+          {saving ? 'Saving…' : 'Save Preferences'}
+        </button>
+        <button
+          onClick={loadPreview}
+          disabled={loadingPreview || sections.length === 0}
+          className="px-4 py-2 rounded-md border text-sm font-medium disabled:opacity-50"
+        >
+          {loadingPreview ? 'Loading…' : 'Preview This Week'}
+        </button>
+      </div>
+
+      {message && <p className="text-sm text-muted-foreground">{message}</p>}
+
+      {preview && (
+        <div className="border rounded-lg p-4 space-y-3">
+          <h4 className="font-semibold">Preview</h4>
+          {preview.newResources.length > 0 && (
+            <div>
+              <p className="text-sm font-medium">New This Week</p>
+              <ul className="text-sm list-disc list-inside">
+                {preview.newResources.map((r) => (
+                  <li key={r.id}>{r.title}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {preview.topPicks.length > 0 && (
+            <div>
+              <p className="text-sm font-medium">Top Picks</p>
+              <ul className="text-sm list-disc list-inside">
+                {preview.topPicks.map((r) => (
+                  <li key={r.id}>{r.title}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {preview.communityHighlights.length > 0 && (
+            <div>
+              <p className="text-sm font-medium">Community Highlights</p>
+              <ul className="text-sm list-disc list-inside">
+                {preview.communityHighlights.map((r) => (
+                  <li key={r.id}>{r.title}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {preview.newResources.length === 0 &&
+            preview.topPicks.length === 0 &&
+            preview.communityHighlights.length === 0 && (
+              <p className="text-sm text-muted-foreground">Nothing to show yet for the selected sections.</p>
+            )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/digest.ts
+++ b/lib/digest.ts
@@ -1,0 +1,106 @@
+import { prisma } from '@/lib/prisma';
+
+export const DIGEST_SECTIONS = ['new_resources', 'top_picks', 'community_highlights'] as const;
+export type DigestSection = (typeof DIGEST_SECTIONS)[number];
+
+export const DIGEST_FREQUENCIES = ['weekly', 'biweekly'] as const;
+export type DigestFrequency = (typeof DIGEST_FREQUENCIES)[number];
+
+const FREQUENCY_TO_DAYS: Record<DigestFrequency, number> = {
+  weekly: 7,
+  biweekly: 14,
+};
+
+export interface DigestContent {
+  periodStart: string;
+  periodEnd: string;
+  newResources: Array<{ id: string; title: string; url: string; category: string; difficulty: string | null }>;
+  topPicks: Array<{ id: string; title: string; url: string; rating: number | null }>;
+  communityHighlights: Array<{ id: string; title: string; url: string; author: string | null }>;
+}
+
+// Builds digest content from the resource catalog. "top_picks" and
+// "community_highlights" are adapted to the resources already available in
+// this codebase (issue #397/#398's Snippet and ResourceSubmission models
+// are not yet merged into main) rather than left unimplemented.
+export async function buildDigestContent(
+  sections: DigestSection[],
+  frequency: DigestFrequency,
+  difficultyFilter: string | null
+): Promise<DigestContent> {
+  const days = FREQUENCY_TO_DAYS[frequency];
+  const periodEnd = new Date();
+  const periodStart = new Date(periodEnd.getTime() - days * 24 * 60 * 60 * 1000);
+
+  const difficultyWhere = difficultyFilter ? { difficulty: difficultyFilter } : {};
+
+  const content: DigestContent = {
+    periodStart: periodStart.toISOString(),
+    periodEnd: periodEnd.toISOString(),
+    newResources: [],
+    topPicks: [],
+    communityHighlights: [],
+  };
+
+  if (sections.includes('new_resources')) {
+    const resources = await prisma.resource.findMany({
+      where: { createdAt: { gte: periodStart }, ...difficultyWhere },
+      orderBy: { createdAt: 'desc' },
+      take: 10,
+      select: { id: true, title: true, url: true, category: true, difficulty: true },
+    });
+    content.newResources = resources;
+  }
+
+  if (sections.includes('top_picks')) {
+    const resources = await prisma.resource.findMany({
+      where: { rating: { not: null }, ...difficultyWhere },
+      orderBy: { rating: 'desc' },
+      take: 5,
+      select: { id: true, title: true, url: true, rating: true },
+    });
+    content.topPicks = resources;
+  }
+
+  if (sections.includes('community_highlights')) {
+    const resources = await prisma.resource.findMany({
+      where: { author: { not: null }, createdAt: { gte: periodStart }, ...difficultyWhere },
+      orderBy: { createdAt: 'desc' },
+      take: 5,
+      select: { id: true, title: true, url: true, author: true },
+    });
+    content.communityHighlights = resources;
+  }
+
+  return content;
+}
+
+export function renderDigestEmail(content: DigestContent, unsubscribeUrl: string): string {
+  const section = (title: string, rows: string[]) =>
+    rows.length ? `<h2>${title}</h2><ul>${rows.join('')}</ul>` : '';
+
+  const newResourcesHtml = section(
+    'New This Week',
+    content.newResources.map((r) => `<li><a href="${r.url}">${r.title}</a> (${r.difficulty ?? 'any level'}, ${r.category})</li>`)
+  );
+
+  const topPicksHtml = section(
+    'Top Picks',
+    content.topPicks.map((r) => `<li><a href="${r.url}">${r.title}</a> — rated ${r.rating?.toFixed(1)}</li>`)
+  );
+
+  const communityHtml = section(
+    'Community Highlights',
+    content.communityHighlights.map((r) => `<li><a href="${r.url}">${r.title}</a> by ${r.author}</li>`)
+  );
+
+  return `
+    <div>
+      <h1>Your Dev Pocket Digest</h1>
+      ${newResourcesHtml}
+      ${topPicksHtml}
+      ${communityHtml}
+      <p><a href="${unsubscribeUrl}">Unsubscribe</a></p>
+    </div>
+  `.trim();
+}

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,32 @@
+interface SendEmailParams {
+  to: string;
+  subject: string;
+  html: string;
+}
+
+// Uses the Resend HTTP API directly via fetch to avoid adding a new SDK
+// dependency. Falls back to logging when RESEND_API_KEY is not configured,
+// so local development and CI (which have no email credentials) never fail.
+export async function sendEmail({ to, subject, html }: SendEmailParams): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.DIGEST_FROM_EMAIL || 'digest@devpocket.dev';
+
+  if (!apiKey) {
+    console.log(`[email:dev] Would send "${subject}" to ${to}`);
+    return;
+  }
+
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ from, to, subject, html }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Failed to send email: ${res.status} ${body}`);
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -276,3 +276,21 @@ model Resource {
   @@index([category])
   @@index([tags])
 }
+
+model DigestSubscription {
+  id               String    @id @default(uuid())
+  userId           String    @unique // Clerk userId
+  email            String
+  frequency        String    @default("weekly") // "weekly" | "biweekly"
+  sections         Json      // e.g. ["new_resources", "top_picks", "community_highlights"]
+  difficultyFilter String?   // "beginner" | "intermediate" | "advanced" | null (all levels)
+  unsubscribeToken String    @unique @default(uuid())
+  isActive         Boolean   @default(true)
+  lastSentAt       DateTime?
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  @@index([userId])
+  @@index([isActive])
+  @@index([frequency])
+}


### PR DESCRIPTION
## Summary

Closes #400

Implements a personalized recurring email digest subscription, letting users choose how often they hear from Dev Pocket, what content to see, and at what difficulty level — configurable entirely from profile settings.

## Features Implemented

### Database Schema
- `DigestSubscription`: one record per Clerk user (`@unique userId`), storing `frequency` (weekly/biweekly), `sections` (JSON array), `difficultyFilter`, `isActive`, `lastSentAt`, and a unique `unsubscribeToken` used for no-login unsubscribe links

### Content Generation (`lib/digest.ts`)
- Builds digest content scoped to the subscription's lookback window (7 or 14 days) and optional difficulty filter
- **Note on scope**: the issue references "top-voted snippets" and "community submissions," which come from the Snippet (#398) and Resource Submission Portal (#397) features — neither is merged into `main` yet. Rather than leave those sections broken or stub them out, this PR adapts the three sections to what the current schema actually supports: **New Resources** (recently added), **Top Picks** (highest-rated resources), and **Community Highlights** (resources with a community `author`). Once #397/#398 land, swapping in real snippet/vote data is a small change scoped to `buildDigestContent()` only.

### Email Delivery (`lib/email.ts`)
- Sends via the Resend HTTP API directly through `fetch` — no new SDK dependency added
- Falls back to a console log when `RESEND_API_KEY` is unset, so local dev and CI never need real email credentials

### REST API Endpoints
1. **GET/POST /api/digest/preferences** - Fetch or save frequency/sections/difficulty (auth required); pulls the verified email from the Clerk user record
2. **GET /api/digest/preview** - Renders the current week's digest for any section/frequency/difficulty combination, without requiring a saved subscription — satisfies the "preview before subscribing" requirement
3. **GET /api/digest/unsubscribe?token=...** - Token-based, deliberately **no authentication required**, matching the one-click unsubscribe requirement
4. **POST /api/digest/send** - Batch send endpoint gated by a shared `x-cron-secret` header (meant to be triggered by an external scheduler like Vercel Cron, since this app has no background job runner); only sends to subscriptions past their frequency interval

### UI
- `DigestPreferences` component: frequency radio buttons, section checkboxes, difficulty select, live preview panel — wired into `/settings`

### Testing
- Section-scoped query verification (only fetches sections that were requested)
- Difficulty filter propagation
- Conditional email rendering (sections with no content are omitted)

## Acceptance Criteria Met

✅ Users can opt in and configure digest preferences from the profile page
✅ Digest emails respect each subscription's configured schedule (weekly/biweekly interval enforced in the send job)
✅ Content matches the user's selected sections and difficulty filter
✅ Unsubscribe link works without requiring login (token-based)
✅ A preview of the current week's digest is visible in settings before subscribing

## Testing Evidence

```
npm run build: ✓ Compiled successfully (also verified without DATABASE_URL/DIRECT_URL set, matching CI env)
npm run lint: 0 errors (135 pre-existing warnings, unchanged)
npm run test: 26 tests passed, 0 failed
```

No merge conflicts with main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Weekly Digest preferences in Settings, including frequency, content sections, and difficulty filters.
  - Added digest previews showing new resources, top picks, and community highlights.
  - Added scheduled digest emails with unsubscribe links.
  - Added support for saving preferences and unsubscribing from digest emails.

- **Tests**
  - Added coverage for digest content filtering, rendering, and section selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->