### PR TITLE
[FEAT] Notes: Make 'View Details' Functional and Add Note Editing

### DIFF
--- a/__tests__/dashboard/notes.view-edit-delete.test.tsx
+++ b/__tests__/dashboard/notes.view-edit-delete.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import NotesPage from '@/app/dashboard/notes/page'
+
+jest.mock('@/lib/toast', () => ({
+  showError: jest.fn()
+}))
+
+describe('NotesPage - view, edit, delete', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem(
+      'dev-pocket-notes',
+      JSON.stringify([
+        { id: 1, title: 'First Note', content: 'Full content of the first note', date: '2025-01-01' }
+      ])
+    )
+  })
+
+  it('opens a modal with the full note when View Details is clicked', () => {
+    render(<NotesPage />)
+
+    fireEvent.click(screen.getByText('View Details'))
+
+    // heading shows the full title (modal uses h2, distinguishing it from
+    // the card's h3) - confirms View Details actually opens something now
+    expect(screen.getByRole('heading', { name: 'First Note', level: 2 })).toBeInTheDocument()
+    expect(screen.getAllByText('Full content of the first note').length).toBeGreaterThan(0)
+  })
+
+  it('opens the edit form pre-filled when Edit is clicked from the view modal', () => {
+    render(<NotesPage />)
+
+    fireEvent.click(screen.getByText('View Details'))
+    fireEvent.click(screen.getByText('Edit'))
+
+    expect(screen.getByRole('heading', { name: 'Edit Note' })).toBeInTheDocument()
+    expect(screen.getByDisplayValue('First Note')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Full content of the first note')).toBeInTheDocument()
+  })
+
+  it('saves changes to an existing note instead of creating a new one', () => {
+    render(<NotesPage />)
+
+    fireEvent.click(screen.getByText('View Details'))
+    fireEvent.click(screen.getByText('Edit'))
+
+    const titleInput = screen.getByDisplayValue('First Note')
+    fireEvent.change(titleInput, { target: { value: 'Updated Title' } })
+    fireEvent.click(screen.getByText('Save Changes'))
+
+    expect(screen.getByText('Updated Title')).toBeInTheDocument()
+    expect(screen.queryByText('First Note')).not.toBeInTheDocument()
+
+    const stored = JSON.parse(localStorage.getItem('dev-pocket-notes') || '[]')
+    expect(stored).toHaveLength(1) // updated in place, not duplicated
+    expect(stored[0].title).toBe('Updated Title')
+  })
+
+  it('does not delete a note when the confirmation is cancelled', () => {
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false)
+    render(<NotesPage />)
+
+    fireEvent.click(screen.getByTitle('Delete note'))
+
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(screen.getByText('First Note')).toBeInTheDocument()
+    confirmSpy.mockRestore()
+  })
+
+  it('deletes a note when the confirmation is accepted', () => {
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true)
+    render(<NotesPage />)
+
+    fireEvent.click(screen.getByTitle('Delete note'))
+
+    expect(screen.queryByText('First Note')).not.toBeInTheDocument()
+    confirmSpy.mockRestore()
+  })
+
+  it('the Add New Note button opens a blank form, not a stale edit', () => {
+    render(<NotesPage />)
+
+    fireEvent.click(screen.getByText('View Details'))
+    fireEvent.click(screen.getByText('Edit'))
+    fireEvent.click(screen.getByText('Cancel'))
+
+    fireEvent.click(screen.getByText('Add New Note'))
+
+    expect(screen.getByRole('heading', { name: 'Create New Note' })).toBeInTheDocument()
+    expect(screen.queryByDisplayValue('First Note')).not.toBeInTheDocument()
+  })
+})

--- a/app/dashboard/notes/page.tsx
+++ b/app/dashboard/notes/page.tsx
@@ -57,24 +57,52 @@ export default function NotesPage() {
   const [searchTerm, setSearchTerm] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [newNote, setNewNote] = useState({ title: "", content: "" });
+  const [editingNoteId, setEditingNoteId] = useState<number | null>(null);
+  const [viewingNote, setViewingNote] = useState<Note | null>(null);
 
-  const handleAddNote = () => {
+  const handleSaveNote = () => {
     if (newNote.title.trim() === "" && newNote.content.trim() === "") return;
 
-    const note: Note = {
-      id: Date.now(),
-      title: newNote.title,
-      content: newNote.content || "",
-      date: new Date().toISOString().split("T")[0],
-    };
+    if (editingNoteId !== null) {
+      setNotes((prevNotes) =>
+        prevNotes.map((note) =>
+          note.id === editingNoteId
+            ? { ...note, title: newNote.title, content: newNote.content }
+            : note
+        )
+      );
+    } else {
+      const note: Note = {
+        id: Date.now(),
+        title: newNote.title,
+        content: newNote.content || "",
+        date: new Date().toISOString().split("T")[0],
+      };
+      setNotes((prevNotes) => [note, ...prevNotes]);
+    }
 
-    setNotes((prevNotes) => [note, ...prevNotes]);
     setNewNote({ title: "", content: "" });
+    setEditingNoteId(null);
     setIsModalOpen(false);
   };
 
+  const closeNoteModal = () => {
+    setIsModalOpen(false);
+    setEditingNoteId(null);
+    setNewNote({ title: "", content: "" });
+  };
+
+  const handleEditNote = (note: Note) => {
+    setNewNote({ title: note.title, content: note.content });
+    setEditingNoteId(note.id);
+    setViewingNote(null);
+    setIsModalOpen(true);
+  };
+
   const handleDeleteNote = (id: number) => {
+    if (!window.confirm("Delete this note? This cannot be undone.")) return;
     setNotes((prevNotes) => prevNotes.filter((note) => note.id !== id));
+    setViewingNote((prev) => (prev?.id === id ? null : prev));
   };
 
   // 🔍 Search filtering logic
@@ -97,7 +125,11 @@ export default function NotesPage() {
         </div>
 
         <button
-          onClick={() => setIsModalOpen(true)}
+          onClick={() => {
+            setNewNote({ title: "", content: "" });
+            setEditingNoteId(null);
+            setIsModalOpen(true);
+          }}
           className="inline-flex items-center gap-2 bg-linear-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white px-4 py-2 rounded-xl font-medium shadow-lg shadow-blue-500/20 transition-all duration-200"
         >
           <Plus className="w-4 h-4" />
@@ -137,7 +169,10 @@ export default function NotesPage() {
               >
                 <Trash2 className="w-4 h-4" />
               </button>
-              <button className="text-sm font-medium text-blue-600 hover:text-blue-700 transition-colors">
+              <button
+                onClick={() => setViewingNote(note)}
+                className="text-sm font-medium text-blue-600 hover:text-blue-700 transition-colors"
+              >
                 View Details
               </button>
             </div>
@@ -164,9 +199,11 @@ export default function NotesPage() {
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-2xl shadow-xl w-full max-w-lg">
             <div className="flex justify-between items-center border-b border-slate-200/60 p-5">
-              <h2 className="text-lg font-semibold text-slate-900">Create New Note</h2>
+              <h2 className="text-lg font-semibold text-slate-900">
+                {editingNoteId !== null ? "Edit Note" : "Create New Note"}
+              </h2>
               <button
-                onClick={() => setIsModalOpen(false)}
+                onClick={closeNoteModal}
                 className="text-slate-400 hover:text-slate-500 transition-colors"
               >
                 <X className="w-5 h-5" />
@@ -203,16 +240,55 @@ export default function NotesPage() {
 
             <div className="flex justify-end gap-3 p-5 border-t border-slate-200/60">
               <button
-                onClick={() => setIsModalOpen(false)}
+                onClick={closeNoteModal}
                 className="px-4 py-2 text-slate-600 hover:text-slate-800 font-medium"
               >
                 Cancel
               </button>
               <button
-                onClick={handleAddNote}
+                onClick={handleSaveNote}
                 className="px-4 py-2 bg-linear-to-r from-blue-500 to-purple-500 text-white font-medium rounded-xl"
               >
-                Save Note
+                {editingNoteId !== null ? "Save Changes" : "Save Note"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* View Note Modal */}
+      {viewingNote && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-2xl shadow-xl w-full max-w-lg">
+            <div className="flex justify-between items-center border-b border-slate-200/60 p-5">
+              <h2 className="text-lg font-semibold text-slate-900 truncate pr-4">
+                {viewingNote.title}
+              </h2>
+              <button
+                onClick={() => setViewingNote(null)}
+                className="text-slate-400 hover:text-slate-500 transition-colors flex-shrink-0"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            <div className="p-5">
+              <p className="text-xs text-slate-500 mb-3">{viewingNote.date}</p>
+              <p className="text-slate-700 whitespace-pre-wrap">{viewingNote.content}</p>
+            </div>
+
+            <div className="flex justify-end gap-3 p-5 border-t border-slate-200/60">
+              <button
+                onClick={() => setViewingNote(null)}
+                className="px-4 py-2 text-slate-600 hover:text-slate-800 font-medium"
+              >
+                Close
+              </button>
+              <button
+                onClick={() => handleEditNote(viewingNote)}
+                className="px-4 py-2 bg-linear-to-r from-blue-500 to-purple-500 text-white font-medium rounded-xl"
+              >
+                Edit
               </button>
             </div>
           </div>


### PR DESCRIPTION
Closes #412

## Summary

This PR completes the Notes page by fixing a non-functional **View Details** button, adding support for editing existing notes, and introducing a confirmation prompt before deletion.

Previously, clicking **View Details** had no effect because it wasn't connected to any handler. There was also no way to edit a note—correcting even a small typo required deleting and recreating it, which also reset its original creation date.

## Changes

### `app/dashboard/notes/page.tsx`

* Added `viewingNote` and `editingNoteId` state to manage the View and Edit flows independently.
* Connected the **View Details** button to open a modal displaying the note's full title and complete content. This allows users to read long notes that were previously truncated by `line-clamp-3`.
* Added an **Edit** button inside the View modal that opens the existing Add Note form with the current note values pre-filled.
* Replaced `handleAddNote` with `handleSaveNote`, which checks `editingNoteId` to decide whether to create a new note or update an existing one.
* Reused the same modal for both creating and editing notes, with the primary button label updating automatically ("Save Note" or "Save Changes").
* Added a `closeNoteModal` helper to consistently reset the form and editing state when closing the modal, cancelling, or after a successful save. This prevents a cancelled edit from affecting the next "Add New Note" action.
* Added a `window.confirm` prompt before deleting a note to help prevent accidental permanent deletion.

## Testing

*  `npm run lint` — 0 errors (140 pre-existing warnings elsewhere in the repository; none introduced by this change).
*  `npm run build` — Successful build with no TypeScript errors.
*  `npx jest __tests__/dashboard/notes.view-edit-delete.test.tsx` — 6/6 tests passing, covering:

  * Opening **View Details** and displaying the full note
  * Edit form pre-filled with existing values
  * Updating a note in place without creating duplicates
  * Delete cancelled vs. delete confirmed
  * Ensuring a cancelled edit doesn't affect the next note creation
*  Full test suite — No new test failures introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to view note details in a separate modal.
  * Added editing and updating for existing notes.
  * Added confirmation before deleting notes.
  * Improved note creation and editing flows with clear modal labels and actions.

* **Bug Fixes**
  * Ensured deleted notes are removed from the open detail view.
  * Reset form and editing state when creating or closing notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->